### PR TITLE
A fix of the fix for the DNS settings.

### DIFF
--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackHeatWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackHeatWrapper.java
@@ -229,7 +229,9 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
           cidr = subnets.get(subnetIndex);
           subnet.putProperty("cidr", cidr);
           //TODO remove this static DNS allocation in future use and implement the DNS as a VIM config parameter
-          subnet.putProperty("dns_nameservers","[\"10.30.0.11\",\"8.8.8.8\"]");
+          //String[] dnsArray = { "10.30.0.11", "8.8.8.8" };
+          String[] dnsArray = { "8.8.8.8" };
+          subnet.putProperty("dns_nameservers", dnsArray);
           // subnet.putProperty("gateway_ip", myPool.getGateway(cidr));
           // subnet.putProperty("cidr", "192.168." + subnetIndex + ".0/24");
           // subnet.putProperty("gateway_ip", "192.168." + subnetIndex + ".1");


### PR DESCRIPTION
The DNS name servers have to be a real Java array instead of a JSON array string. Thus, the array is translated to YAML (by Jackson) correctly.