### PR TITLE
Ignore unknown fields in YAML payload.

### DIFF
--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployServiceCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployServiceCallProcessor.java
@@ -72,6 +72,7 @@ public class DeployServiceCallProcessor extends AbstractCallProcessor {
     module.addDeserializer(Unit.class, new UnitDeserializer());
     mapper.registerModule(module);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     try {
       data = mapper.readValue(message.getBody(), DeployServiceData.class);
       Logger.info("payload parsed");

--- a/wim-adaptor/adaptor/src/main/java/sonata/kernel/WimAdaptor/ConfigureWimCallProcessor.java
+++ b/wim-adaptor/adaptor/src/main/java/sonata/kernel/WimAdaptor/ConfigureWimCallProcessor.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import sonata.kernel.WimAdaptor.commons.DeployServiceResponse;
+import sonata.kernel.WimAdaptor.commons.Status;
+import sonata.kernel.WimAdaptor.commons.VnfRecord;
 import sonata.kernel.WimAdaptor.commons.vnfd.UnitDeserializer;
 import sonata.kernel.WimAdaptor.messaging.ServicePlatformMessage;
 import sonata.kernel.WimAdaptor.wrapper.WrapperBay;
@@ -69,6 +71,10 @@ public class ConfigureWimCallProcessor extends AbstractCallProcessor {
     ServicePlatformMessage responseMessage = null;
     if (wim.configureNetwork(instanceId)) {
       response.setVimUuid(null);
+      // response.getNsr().setStatus(Status.normal_operation);
+      // for (VnfRecord vnfr:response.getVnfrs()){
+      // vnfr.setStatus(Status.normal_operation);
+      // }
       String body;
       try {
         Logger.debug("Serialising deploy response...");


### PR DESCRIPTION
VIM Adaptor:

* Disabled the generation of exception for unkonw fields in the YAML de-serializer

WIM adaptor:

* The actual "normal operation" status is set for VNFR and NSR after the WIM configuration, but currently disabled.