### PR TITLE
Vim-adaptor edits:

### DIFF
--- a/vim-adaptor/adaptor/YAML/Payload_deploy_service.yml
+++ b/vim-adaptor/adaptor/YAML/Payload_deploy_service.yml
@@ -28,11 +28,11 @@ nsd:
     vnf_version: "0.1"
   connection_points:
   - id: "ns:mgmt"
-    type: "interface"
+    type: "public"
   - id: "ns:input"
-    type: "interface"
+    type: "internal"
   - id: "ns:output"
-    type: "interface"
+    type: "internal"
   virtual_links:
   - id: "mgmt"
     access: false
@@ -133,18 +133,18 @@ vnfdList:
         size_unit: "GB"
     connection_points:
     - id: "vdu01:cp01"
-      type: "interface"
+      type: "public"
     - id: "vdu01:cp02"
-      type: "interface"
+      type: "internal"
     - id: "vdu01:cp03"
-      type: "interface"
+      type: "internal"
   connection_points:
   - id: "vnf:mgmt"
-    type: "interface"
+    type: "public"
   - id: "vnf:input"
-    type: "interface"
+    type: "internal"
   - id: "vnf:output"
-    type: "interface"
+    type: "internal"
   virtual_links:
   - id: "mgmt"
     access: false
@@ -197,18 +197,18 @@ vnfdList:
         size_unit: "GB"
     connection_points:
     - id: "vdu01:cp01"
-      type: "interface"
+      type: "public"
     - id: "vdu01:cp02"
-      type: "interface"
+      type: "internal"
     - id: "vdu01:cp03"
-      type: "interface"
+      type: "internal"
   connection_points:
   - id: "vnf:mgmt"
-    type: "interface"
+    type: "public"
   - id: "vnf:input"
-    type: "interface"
+    type: "internal"
   - id: "vnf:output"
-    type: "interface"
+    type: "internal"
   virtual_links:
   - id: "mgmt"
     access: false
@@ -262,18 +262,18 @@ vnfdList:
         size_unit: "GB"
     connection_points:
     - id: "vdu01:cp01"
-      type: "interface"
+      type: "public"
     - id: "vdu01:cp02"
-      type: "interface"
+      type: "internal"
     - id: "vdu01:cp03"
-      type: "interface"
+      type: "internal"
   connection_points:
   - id: "vnf:mgmt"
-    type: "interface"
+    type: "public"
   - id: "vnf:input"
-    type: "interface"
+    type: "internal"
   - id: "vnf:output"
-    type: "interface"
+    type: "internal"
   virtual_links:
   - id: "mgmt"
     access: false

--- a/vim-adaptor/adaptor/YAML/fw-vnf-vnfd.yml
+++ b/vim-adaptor/adaptor/YAML/fw-vnf-vnfd.yml
@@ -61,10 +61,10 @@ virtual_links:
 ##
 connection_points:
   - id: "vnf:mgmt"
-    type: "interface"
+    type: "public"
   - id: "vnf:input"
-    type: "interface"
+    type: "internal"
   - id: "vnf:output"
-    type: "interface"
+    type: "internal"
 uuid: 6a15313f-cb0a-4540-baa2-77cc6b3f5678
 instance_uuid: 6a15313f-cb0a-4540-baa2-77cc6b3f0000

--- a/vim-adaptor/adaptor/YAML/fw-vnf-vnfd.yml
+++ b/vim-adaptor/adaptor/YAML/fw-vnf-vnfd.yml
@@ -28,11 +28,11 @@ virtual_deployment_units:
         size_unit: "GB"
     connection_points:
       - id: "vdu01:eth0"
-        type: "interface"
+        type: "public"
       - id: "vdu01:eth1"
-        type: "interface"
+        type: "internal"
       - id: "vdu01:eth2"
-        type: "interface"
+        type: "internal"
 
 ##
 ## The virtual links that interconnect

--- a/vim-adaptor/adaptor/YAML/nsd-schema.yml
+++ b/vim-adaptor/adaptor/YAML/nsd-schema.yml
@@ -9,7 +9,9 @@ description: "The core scheme for RECUSRIVE service descriptors (many details le
 definitions:
   interfaces:
     enum:
-      - "interface"
+      - "external"
+      - "internal"
+      - "public"
 
 ##
 ## The actual document description.

--- a/vim-adaptor/adaptor/YAML/sonata-demo.yml
+++ b/vim-adaptor/adaptor/YAML/sonata-demo.yml
@@ -35,11 +35,11 @@ network_functions:
 ##
 connection_points:
   - id: "ns:mgmt"
-    type: "interface"
+    type: "public"
   - id: "ns:input"
-    type: "interface"
+    type: "internal"
   - id: "ns:output"
-    type: "interface"
+    type: "internal"
 
 ##
 ## The virtual links that interconnect

--- a/vim-adaptor/adaptor/YAML/sonata-demo1.yml
+++ b/vim-adaptor/adaptor/YAML/sonata-demo1.yml
@@ -31,11 +31,11 @@ network_functions:
 ##
 connection_points:
   - id: "ns:mgmt"
-    type: "interface"
+    type: "public"
   - id: "ns:input"
-    type: "interface"
+    type: "internal"
   - id: "ns:output"
-    type: "interface"
+    type: "internal"
 
 ##
 ## The virtual links that interconnect

--- a/vim-adaptor/adaptor/YAML/vTC-vnfd.yml
+++ b/vim-adaptor/adaptor/YAML/vTC-vnfd.yml
@@ -49,7 +49,7 @@ virtual_deployment_units:
         unit: "Mbps"
     connection_points:
       - id: "vdu01:eth0"
-        type: "interface"
+        type: "public"
   - id: "vdu02"
     vm_image: "pfring_api_module"
     description: "VNFC for the DPI functionality"
@@ -74,11 +74,11 @@ virtual_deployment_units:
         unit: "Mbps"
     connection_points:
       - id: "vdu02:eth0"
-        type: "interface" 
+        type: "public" 
       - id: "vdu02:eth1"
-        type: "interface"
+        type: "internal"
       - id: "vdu02:eth2"
-        type: "interface"
+        type: "internal"
 
 virtual_links:
   - id: "mgmt"
@@ -103,11 +103,11 @@ virtual_links:
 
 connection_points:
 - id: "vnf:mgmt"
-  type: interface
+  type: public
 - id: "vnf:input"
-  type: interface
+  type: internal
 - id: "vnf:output"
-  type: interface
+  type: internal
 
 monitoring_rules:
   - name: "mon:rule:vm_cpu_perc"

--- a/vim-adaptor/adaptor/YAML/vnfd-schema.yml
+++ b/vim-adaptor/adaptor/YAML/vnfd-schema.yml
@@ -52,6 +52,8 @@ definitions:
   interfaces:
     enum:
       - "interface"
+      - "external"
+      - "public"
   monitoring:
     type: "object"
     properties:

--- a/vim-adaptor/adaptor/YAML/vtc-vnf-vnfd.yml
+++ b/vim-adaptor/adaptor/YAML/vtc-vnf-vnfd.yml
@@ -49,11 +49,11 @@ virtual_deployment_units:
         unit: "Mbps"
     connection_points:
       - id: "vdu01:eth0"
-        type: "interface"
+        type: "public"
       - id: "vdu01:eth1"
-        type: "interface"
+        type: "internal"
       - id: "vdu01:eth2"
-        type: "interface"
+        type: "internal"
 
 virtual_links:
   - id: "mgmt"

--- a/vim-adaptor/adaptor/YAML/vtc-vnf-vnfd.yml.save
+++ b/vim-adaptor/adaptor/YAML/vtc-vnf-vnfd.yml.save
@@ -1,4 +1,4 @@
-descriptor_version: "vnfd-schema-01"
+escriptor_version: "vnfd-schema-01"
 vendor: "eu.sonata-nfv"
 name: "vtc-vnf"
 version: "0.1"
@@ -77,11 +77,11 @@ virtual_links:
 
 connection_points:
 - id: "vnf:mgmt"
-  type: public
+  type: interface
 - id: "vnf:input"
-  type: internal
+  type: interface
 - id: "vnf:output"
-  type: internal
+  type: interface
 
 monitoring_rules:
   - name: "mon:rule:vm_cpu_perc"

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
@@ -111,7 +111,7 @@ public class AdaptorDispatcher implements Runnable {
   
   private void handleFunctionMessage(ServicePlatformMessage message){
     if (message.getTopic().endsWith("deploy")) {
-      myThreadPool.execute(new DeployFunctionServiceCallProcessor(message,message.getSid(),mux));
+      myThreadPool.execute(new DeployFunctionCallProcessor(message,message.getSid(),mux));
     }
   }
 

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
@@ -80,11 +80,19 @@ public class AdaptorDispatcher implements Runnable {
           handleFunctionMessage(message);
         } else if (isMonitoringMessage(message)) {
           this.handleMonitoringMessage(message);
+        } else if (isNetworkMsg(message)) {
+          this.handleNetworkingMessage(message);
         }
       } catch (InterruptedException e) {
         Logger.error(e.getMessage(), e);
       }
     } while (!stop);
+  }
+
+  private void handleNetworkingMessage(ServicePlatformMessage message) {
+    if (message.getTopic().endsWith("configure")) {
+      myThreadPool.execute(new ConfigureNetworkCallProcessor(message, message.getSid(), mux));
+    }
   }
 
   private void handleMonitoringMessage(ServicePlatformMessage message) {
@@ -108,10 +116,10 @@ public class AdaptorDispatcher implements Runnable {
       myThreadPool.execute(new PrepareServiceCallProcessor(message, message.getSid(), mux));
     }
   }
-  
-  private void handleFunctionMessage(ServicePlatformMessage message){
+
+  private void handleFunctionMessage(ServicePlatformMessage message) {
     if (message.getTopic().endsWith("deploy")) {
-      myThreadPool.execute(new DeployFunctionCallProcessor(message,message.getSid(),mux));
+      myThreadPool.execute(new DeployFunctionCallProcessor(message, message.getSid(), mux));
     }
   }
 
@@ -148,6 +156,10 @@ public class AdaptorDispatcher implements Runnable {
 
   private boolean isServiceMsg(ServicePlatformMessage message) {
     return message.getTopic().contains("infrastructure.service");
+  }
+
+  private boolean isNetworkMsg(ServicePlatformMessage message) {
+    return message.getTopic().contains("infrastructure.network");
   }
 
   private boolean isMonitoringMessage(ServicePlatformMessage message) {

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
@@ -81,7 +81,7 @@ public class AdaptorDispatcher implements Runnable {
         } else if (isMonitoringMessage(message)) {
           this.handleMonitoringMessage(message);
         } else if (isNetworkMsg(message)) {
-          this.handleNetworkingMessage(message);
+          this.handleNetworkMessage(message);
         }
       } catch (InterruptedException e) {
         Logger.error(e.getMessage(), e);
@@ -89,8 +89,9 @@ public class AdaptorDispatcher implements Runnable {
     } while (!stop);
   }
 
-  private void handleNetworkingMessage(ServicePlatformMessage message) {
+  private void handleNetworkMessage(ServicePlatformMessage message) {
     if (message.getTopic().endsWith("configure")) {
+      Logger.info("Received a \"Network\" API call on topic: "+message.getTopic());
       myThreadPool.execute(new ConfigureNetworkCallProcessor(message, message.getSid(), mux));
     }
   }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
@@ -76,6 +76,8 @@ public class AdaptorDispatcher implements Runnable {
           handleManagementMessage(message);
         } else if (isServiceMsg(message)) {
           this.handleServiceMsg(message);
+        } else if (isFunctionMessage(message)) {
+          handleFunctionMessage(message);
         } else if (isMonitoringMessage(message)) {
           this.handleMonitoringMessage(message);
         }
@@ -104,6 +106,12 @@ public class AdaptorDispatcher implements Runnable {
     } else if (message.getTopic().endsWith("prepare")) {
       Logger.info("Received a \"service.prepare\" API call on topic: " + message.getTopic());
       myThreadPool.execute(new PrepareServiceCallProcessor(message, message.getSid(), mux));
+    }
+  }
+  
+  private void handleFunctionMessage(ServicePlatformMessage message){
+    if (message.getTopic().endsWith("deploy")) {
+      myThreadPool.execute(new DeployFunctionServiceCallProcessor(message,message.getSid(),mux));
     }
   }
 
@@ -144,6 +152,10 @@ public class AdaptorDispatcher implements Runnable {
 
   private boolean isMonitoringMessage(ServicePlatformMessage message) {
     return message.getTopic().contains("infrastructure.monitoring");
+  }
+
+  private boolean isFunctionMessage(ServicePlatformMessage message) {
+    return message.getTopic().contains("infrastructure.function");
   }
 
   private boolean isRegistrationResponse(ServicePlatformMessage message) {

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AdaptorDispatcher.java
@@ -99,8 +99,11 @@ public class AdaptorDispatcher implements Runnable {
     if (message.getTopic().endsWith("deploy")) {
       myThreadPool.execute(new DeployServiceCallProcessor(message, message.getSid(), mux));
     } else if (message.getTopic().endsWith("remove")) {
-      Logger.info("Received a \"remove-service\" API call on topic: " + message.getTopic());
+      Logger.info("Received a \"service.remove\" API call on topic: " + message.getTopic());
       myThreadPool.execute(new RemoveServiceCallProcessor(message, message.getSid(), mux));
+    } else if (message.getTopic().endsWith("prepare")) {
+      Logger.info("Received a \"service.prepare\" API call on topic: " + message.getTopic());
+      myThreadPool.execute(new PrepareServiceCallProcessor(message, message.getSid(), mux));
     }
   }
 

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AddVimCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AddVimCallProcessor.java
@@ -28,16 +28,21 @@ package sonata.kernel.VimAdaptor;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import org.slf4j.LoggerFactory;
 
 import sonata.kernel.VimAdaptor.messaging.ServicePlatformMessage;
 import sonata.kernel.VimAdaptor.wrapper.WrapperBay;
 import sonata.kernel.VimAdaptor.wrapper.WrapperConfiguration;
+import sonata.kernel.VimAdaptor.wrapper.WrapperFactory;
 
 import java.util.Observable;
 import java.util.UUID;
 
 public class AddVimCallProcessor extends AbstractCallProcessor {
 
+  private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(AddVimCallProcessor.class);
+
+  
   /**
    * Generate a CallProcessor to process an API call to create a new VIM wrapper
    * 
@@ -65,8 +70,8 @@ public class AddVimCallProcessor extends AbstractCallProcessor {
     String wrapperType = null;
     if (message.getTopic().contains("compute")) {
       wrapperType = "compute";
-    } else if (message.getTopic().contains("networking")){
-      wrapperType = "networking";
+    } else if (message.getTopic().contains("network")){
+      wrapperType = "network";
     }
     String vimVendor = jsonObject.getString("vim_type");
     String vimEndpoint = jsonObject.getString("vim_address");
@@ -81,7 +86,7 @@ public class AddVimCallProcessor extends AbstractCallProcessor {
     if (wrapperType.equals("compute")) {
       tenantExtNet = jsonObject.getString("tenant_ext_net");
       tenantExtRouter = jsonObject.getString("tenant_ext_router");
-    } else if (wrapperType.equals("networking")) {
+    } else if (wrapperType.equals("network")) {
       computeVimRef = jsonObject.getString("compute_uuid");
     }
     config.setUuid(UUID.randomUUID().toString());
@@ -101,8 +106,9 @@ public class AddVimCallProcessor extends AbstractCallProcessor {
     } else if (wrapperType.equals("storage")) {
       // TODO
       output = "";
-    } else if (wrapperType.equals("networking")) {
-      output = WrapperBay.getInstance().registerNetworkingWrapper(config, computeVimRef);
+    } else if (wrapperType.equals("network")) {
+      Logger.debug("Registering a network VIM");
+      output = WrapperBay.getInstance().registerNetworkWrapper(config, computeVimRef);
     }
     this.sendResponse(output);
 

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AddVimCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/AddVimCallProcessor.java
@@ -61,7 +61,13 @@ public class AddVimCallProcessor extends AbstractCallProcessor {
     WrapperConfiguration config = new WrapperConfiguration();
 
     JSONObject jsonObject = (JSONObject) tokener.nextValue();
-    String wrapperType = jsonObject.getString("wr_type");
+
+    String wrapperType = null;
+    if (message.getTopic().contains("compute")) {
+      wrapperType = "compute";
+    } else if (message.getTopic().contains("networking")){
+      wrapperType = "networking";
+    }
     String vimVendor = jsonObject.getString("vim_type");
     String vimEndpoint = jsonObject.getString("vim_address");
     String authUser = jsonObject.getString("username");

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/ConfigureNetworkCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/ConfigureNetworkCallProcessor.java
@@ -1,0 +1,101 @@
+/**
+ * @author Dario Valocchi (Ph.D.)
+ * @mail d.valocchi@ucl.ac.uk
+ * 
+ *       Copyright 2016 [Dario Valocchi]
+ * 
+ *       Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *       except in compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *       Unless required by applicable law or agreed to in writing, software distributed under the
+ *       License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *       either express or implied. See the License for the specific language governing permissions
+ *       and limitations under the License.
+ * 
+ */
+package sonata.kernel.VimAdaptor;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.slf4j.LoggerFactory;
+
+import sonata.kernel.VimAdaptor.commons.FunctionDeployPayload;
+import sonata.kernel.VimAdaptor.commons.NetworkConfigurePayload;
+import sonata.kernel.VimAdaptor.commons.vnfd.Unit;
+import sonata.kernel.VimAdaptor.commons.vnfd.UnitDeserializer;
+import sonata.kernel.VimAdaptor.messaging.ServicePlatformMessage;
+import sonata.kernel.VimAdaptor.wrapper.ComputeWrapper;
+import sonata.kernel.VimAdaptor.wrapper.WrapperBay;
+
+import java.io.IOException;
+import java.util.Observable;
+
+public class ConfigureNetworkCallProcessor extends AbstractCallProcessor {
+
+  NetworkConfigurePayload data = null;
+
+  private static final org.slf4j.Logger Logger =
+      LoggerFactory.getLogger(DeployFunctionCallProcessor.class);
+
+  /**
+   * @param message
+   * @param sid
+   * @param mux
+   */
+  public ConfigureNetworkCallProcessor(ServicePlatformMessage message, String sid,
+      AdaptorMux mux) {
+    super(message, sid, mux);
+  }
+
+  @Override
+  public void run() {
+
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see java.util.Observer#update(java.util.Observable, java.lang.Object)
+   */
+  @Override
+  public void update(Observable arg0, Object arg1) {
+
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see sonata.kernel.VimAdaptor.AbstractCallProcessor#process(sonata.kernel.VimAdaptor.messaging.
+   * ServicePlatformMessage)
+   */
+  @Override
+  public boolean process(ServicePlatformMessage message) {
+
+    data = null;
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(Unit.class, new UnitDeserializer());
+    mapper.registerModule(module);
+    mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    try {
+      data = mapper.readValue(message.getBody(), NetworkConfigurePayload.class);
+      Logger.info("payload parsed");
+    } catch (IOException e) {
+      Logger.error("Unable to parse the payload received");
+    }
+    String responseJson = "{\"status\":\"COMPLETED\",\"message\":\"\"}";
+    Logger.info("Received networking.configure call for service instance " + data.getServiceInstanceId());
+    this.sendToMux(new ServicePlatformMessage(responseJson, "application/json",
+        message.getReplyTo(), message.getSid(), null));
+    return false;
+  }
+
+}

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/ConfigureNetworkCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/ConfigureNetworkCallProcessor.java
@@ -54,11 +54,6 @@ public class ConfigureNetworkCallProcessor extends AbstractCallProcessor {
     super(message, sid, mux);
   }
 
-  @Override
-  public void run() {
-
-  }
-
   /*
    * (non-Javadoc)
    * 

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployFunctionCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployFunctionCallProcessor.java
@@ -34,11 +34,11 @@ import sonata.kernel.VimAdaptor.wrapper.WrapperStatusUpdate;
 
 import java.util.Observable;
 
-public class DeployFunctionServiceCallProcessor extends AbstractCallProcessor {
+public class DeployFunctionCallProcessor extends AbstractCallProcessor {
 
   private FunctionDeployPayload data;
   private static final org.slf4j.Logger Logger =
-      LoggerFactory.getLogger(DeployFunctionServiceCallProcessor.class);
+      LoggerFactory.getLogger(DeployFunctionCallProcessor.class);
 
   /**
    * Basic constructor for the call processor.
@@ -47,7 +47,7 @@ public class DeployFunctionServiceCallProcessor extends AbstractCallProcessor {
    * @param sid
    * @param mux
    */
-  public DeployFunctionServiceCallProcessor(ServicePlatformMessage message, String sid,
+  public DeployFunctionCallProcessor(ServicePlatformMessage message, String sid,
       AdaptorMux mux) {
     super(message, sid, mux);
   }
@@ -96,7 +96,7 @@ public class DeployFunctionServiceCallProcessor extends AbstractCallProcessor {
   @Override
   public boolean process(ServicePlatformMessage message) {
     boolean out = true;
-    Logger.info("Call received...");
+    Logger.info("Deploy function call received by call processor.");
     // parse the payload to get Wrapper UUID and NSD/VNFD from the request body
     Logger.info("Parsing payload...");
     data = null;

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployFunctionCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployFunctionCallProcessor.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.slf4j.LoggerFactory;
 
 import sonata.kernel.VimAdaptor.commons.FunctionDeployPayload;
+import sonata.kernel.VimAdaptor.commons.FunctionDeployResponse;
 import sonata.kernel.VimAdaptor.commons.vnfd.Unit;
 import sonata.kernel.VimAdaptor.commons.vnfd.UnitDeserializer;
 import sonata.kernel.VimAdaptor.messaging.ServicePlatformMessage;

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployFunctionServiceCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployFunctionServiceCallProcessor.java
@@ -1,0 +1,139 @@
+/**
+ * @author Dario Valocchi (Ph.D.)
+ * @mail d.valocchi@ucl.ac.uk
+ * 
+ *       Copyright 2016 [Dario Valocchi]
+ * 
+ *       Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *       except in compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *       Unless required by applicable law or agreed to in writing, software distributed under the
+ *       License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *       either express or implied. See the License for the specific language governing permissions
+ *       and limitations under the License.
+ * 
+ */
+package sonata.kernel.VimAdaptor;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.slf4j.LoggerFactory;
+
+import sonata.kernel.VimAdaptor.commons.FunctionDeployPayload;
+import sonata.kernel.VimAdaptor.commons.vnfd.Unit;
+import sonata.kernel.VimAdaptor.commons.vnfd.UnitDeserializer;
+import sonata.kernel.VimAdaptor.messaging.ServicePlatformMessage;
+import sonata.kernel.VimAdaptor.wrapper.ComputeWrapper;
+import sonata.kernel.VimAdaptor.wrapper.WrapperBay;
+import sonata.kernel.VimAdaptor.wrapper.WrapperStatusUpdate;
+
+import java.util.Observable;
+
+public class DeployFunctionServiceCallProcessor extends AbstractCallProcessor {
+
+  private FunctionDeployPayload data;
+  private static final org.slf4j.Logger Logger =
+      LoggerFactory.getLogger(DeployFunctionServiceCallProcessor.class);
+
+  /**
+   * Basic constructor for the call processor.
+   * 
+   * @param message
+   * @param sid
+   * @param mux
+   */
+  public DeployFunctionServiceCallProcessor(ServicePlatformMessage message, String sid,
+      AdaptorMux mux) {
+    super(message, sid, mux);
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see java.util.Observer#update(java.util.Observable, java.lang.Object)
+   */
+  @Override
+  public void update(Observable o, Object arg) {
+    WrapperStatusUpdate update = (WrapperStatusUpdate) arg;
+    if (update.getSid().equals(this.getSid())) {
+      Logger.info("Received an update from the wrapper...");
+      if (update.getStatus().equals("SUCCESS")) {
+        Logger.info("Deploy " + this.getSid() + " succeed");
+
+        // Sending the response to the FLM
+        Logger.info("Sending partial response to FLM...");
+        ServicePlatformMessage response =
+            new ServicePlatformMessage(update.getBody(), "application/x-yaml",
+                this.getMessage().getReplyTo(), this.getSid(), null);
+        this.sendToMux(response);
+      } else if (update.getStatus().equals("ERROR")) {
+        Logger.warn("Deploy " + this.getSid() + " error");
+        Logger.warn("Pushing back error...");
+        ServicePlatformMessage response = new ServicePlatformMessage(
+            "{\"request_status\":\"fail\",\"message\":\"" + update.getBody() + "\"}",
+            "application/x-yaml", this.getMessage().getReplyTo(), this.getSid(), null);
+        this.sendToMux(response);
+      } else {
+        Logger.info("Deploy " + this.getSid() + " - " + update.getStatus());
+        Logger.info("Message " + update.getBody());
+      }
+
+      // TODO handle other update from the compute wrapper;
+    }
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see sonata.kernel.VimAdaptor.AbstractCallProcessor#process(sonata.kernel.VimAdaptor.messaging.
+   * ServicePlatformMessage)
+   */
+  @Override
+  public boolean process(ServicePlatformMessage message) {
+    boolean out = true;
+    Logger.info("Call received...");
+    // parse the payload to get Wrapper UUID and NSD/VNFD from the request body
+    Logger.info("Parsing payload...");
+    data = null;
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(Unit.class, new UnitDeserializer());
+    mapper.registerModule(module);
+    mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    try {
+      data = mapper.readValue(message.getBody(), FunctionDeployPayload.class);
+      Logger.info("payload parsed");
+      ComputeWrapper wr = WrapperBay.getInstance().getComputeWrapper(data.getVimUuid());
+      Logger.info("Wrapper retrieved");
+
+      if (wr == null) {
+        Logger.warn("Error retrieving the wrapper");
+
+        this.sendToMux(new ServicePlatformMessage(
+            "{\"request_status\":\"fail\",\"message\":\"VIM not found\"}", "application/json",
+            message.getReplyTo(), message.getSid(), null));
+        out = false;
+      } else {
+        // use wrapper interface to send the NSD/VNFD, along with meta-data
+        // to the wrapper, triggering the service instantiation.
+        Logger.info("Calling wrapper: " + wr);
+        wr.addObserver(this);
+        wr.deployFunction(data, this.getSid());
+      }
+    } catch (Exception e) {
+      Logger.error("Error deploying the system: " + e.getMessage(), e);
+      this.sendToMux(new ServicePlatformMessage(
+          "{\"request_status\":\"fail\",\"message\":\"Deployment Error\"}", "application/json",
+          message.getReplyTo(), message.getSid(), null));
+      out = false;
+    }
+    return out;
+  }
+
+}

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployServiceCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/DeployServiceCallProcessor.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import org.slf4j.LoggerFactory;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.vnfd.Unit;
 import sonata.kernel.VimAdaptor.commons.vnfd.UnitDeserializer;
 import sonata.kernel.VimAdaptor.messaging.ServicePlatformMessage;
@@ -48,7 +48,7 @@ public class DeployServiceCallProcessor extends AbstractCallProcessor {
   private static final org.slf4j.Logger Logger =
       LoggerFactory.getLogger(DeployServiceCallProcessor.class);
 
-  private DeployServiceData data;
+  private ServiceDeployPayload data;
 
   /**
    * Create a CallProcessor to process a DeployService API call.
@@ -75,7 +75,7 @@ public class DeployServiceCallProcessor extends AbstractCallProcessor {
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     try {
-      data = mapper.readValue(message.getBody(), DeployServiceData.class);
+      data = mapper.readValue(message.getBody(), ServiceDeployPayload.class);
       Logger.info("payload parsed");
       ComputeWrapper wr = WrapperBay.getInstance().getComputeWrapper(data.getVimUuid());
       Logger.info("Wrapper retrieved");

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/PrepareServiceCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/PrepareServiceCallProcessor.java
@@ -1,0 +1,110 @@
+/**
+ * @author Dario Valocchi (Ph.D.)
+ * @mail d.valocchi@ucl.ac.uk
+ * 
+ *       Copyright 2016 [Dario Valocchi]
+ * 
+ *       Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *       except in compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *       Unless required by applicable law or agreed to in writing, software distributed under the
+ *       License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *       either express or implied. See the License for the specific language governing permissions
+ *       and limitations under the License.
+ * 
+ */
+package sonata.kernel.VimAdaptor;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.slf4j.LoggerFactory;
+
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
+import sonata.kernel.VimAdaptor.commons.ServicePreparePayload;
+import sonata.kernel.VimAdaptor.commons.vnfd.Unit;
+import sonata.kernel.VimAdaptor.commons.vnfd.UnitDeserializer;
+import sonata.kernel.VimAdaptor.messaging.ServicePlatformMessage;
+import sonata.kernel.VimAdaptor.wrapper.ComputeWrapper;
+import sonata.kernel.VimAdaptor.wrapper.WrapperBay;
+
+import java.util.Observable;
+
+public class PrepareServiceCallProcessor extends AbstractCallProcessor {
+  private static final org.slf4j.Logger Logger =
+      LoggerFactory.getLogger(DeployServiceCallProcessor.class);
+
+  /**
+   * @param message
+   * @param sid
+   * @param mux
+   */
+  public PrepareServiceCallProcessor(ServicePlatformMessage message, String sid, AdaptorMux mux) {
+    super(message, sid, mux);
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see java.util.Observer#update(java.util.Observable, java.lang.Object)
+   */
+  @Override
+  public void update(Observable arg0, Object arg1) {
+    // TODO Auto-generated method stub
+
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see sonata.kernel.VimAdaptor.AbstractCallProcessor#process(sonata.kernel.VimAdaptor.messaging.
+   * ServicePlatformMessage)
+   */
+  @Override
+  public boolean process(ServicePlatformMessage message) {
+
+    boolean out = true;
+    Logger.info("Call received...");
+    // parse the payload to get Wrapper UUID and NSD/VNFD from the request body
+    Logger.info("Parsing payload...");
+    ServicePreparePayload payload = null;
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(Unit.class, new UnitDeserializer());
+    mapper.registerModule(module);
+    mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    try {
+      payload = mapper.readValue(message.getBody(), ServicePreparePayload.class);
+      Logger.info("payload parsed. Configuring VIMs");
+
+      for (String vimUuid : payload.getVimList()) {
+        ComputeWrapper wr = WrapperBay.getInstance().getComputeWrapper(vimUuid);
+        Logger.info("Wrapper retrieved");
+        boolean success = wr.prepareService(payload.getInstanceId());
+        if (!success) {
+          throw new Exception("Unable to prepare the environment for instance: "
+              + payload.getInstanceId() + " on VIM " + vimUuid);
+        }
+        
+      }
+      String responseJson = "{\"status\":\"COMPLETED\",\"message\":null}";
+      ServicePlatformMessage responseMessage = new ServicePlatformMessage(responseJson, "application/json", message.getReplyTo(), message.getSid(), null);
+      this.sendToMux(responseMessage);
+      
+    } catch (Exception e) {
+      Logger.error("Error deploying the system: " + e.getMessage(), e);
+      this.sendToMux(new ServicePlatformMessage(
+          "{\"status\":\"fail\",\"message\":\""+e.getMessage()+"\"}", "application/json",
+          message.getReplyTo(), message.getSid(), null));
+      out = false;
+    }
+    return out;
+  }
+
+}

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/PrepareServiceCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/PrepareServiceCallProcessor.java
@@ -93,7 +93,7 @@ public class PrepareServiceCallProcessor extends AbstractCallProcessor {
         }
         
       }
-      String responseJson = "{\"status\":\"COMPLETED\",\"message\":null}";
+      String responseJson = "{\"status\":\"COMPLETED\",\"message\":\"\"}";
       ServicePlatformMessage responseMessage = new ServicePlatformMessage(responseJson, "application/json", message.getReplyTo(), message.getSid(), null);
       this.sendToMux(responseMessage);
       

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/RemoveVimCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/RemoveVimCallProcessor.java
@@ -30,6 +30,7 @@ import org.json.JSONObject;
 import org.json.JSONTokener;
 
 import sonata.kernel.VimAdaptor.messaging.ServicePlatformMessage;
+import sonata.kernel.VimAdaptor.wrapper.Wrapper;
 import sonata.kernel.VimAdaptor.wrapper.WrapperBay;
 
 import java.util.Observable;
@@ -55,7 +56,10 @@ public class RemoveVimCallProcessor extends AbstractCallProcessor {
     JSONTokener tokener = new JSONTokener(message.getBody());
     JSONObject jsonObject = (JSONObject) tokener.nextValue();
     String uuid = jsonObject.getString("uuid");
-    String type = jsonObject.getString("wr_type");
+    if(uuid==null)
+      this.sendResponse("{\"status\":\"ERROR\",\"message\":\"Malformed request\"}");
+    Wrapper wrapper= WrapperBay.getInstance().getWrapper(uuid);
+    String type = wrapper.getType();
     String output = null;
     if (type.equals("compute")) {
       output = WrapperBay.getInstance().removeComputeWrapper(uuid);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/RemoveVimCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/RemoveVimCallProcessor.java
@@ -59,7 +59,12 @@ public class RemoveVimCallProcessor extends AbstractCallProcessor {
     if(uuid==null)
       this.sendResponse("{\"status\":\"ERROR\",\"message\":\"Malformed request\"}");
     Wrapper wrapper= WrapperBay.getInstance().getWrapper(uuid);
-    String type = wrapper.getType();
+    String type =null;
+    if (message.getTopic().contains("compute")) {
+     type = "compute";
+    } else if (message.getTopic().contains("network")){
+      type = "network";
+    }
     String output = null;
     if (type.equals("compute")) {
       output = WrapperBay.getInstance().removeComputeWrapper(uuid);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/FunctionDeployPayload.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/FunctionDeployPayload.java
@@ -1,0 +1,59 @@
+/**
+ * @author Dario Valocchi (Ph.D.)
+ * @mail d.valocchi@ucl.ac.uk
+ * 
+ *       Copyright 2016 [Dario Valocchi]
+ * 
+ *       Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *       except in compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *       Unless required by applicable law or agreed to in writing, software distributed under the
+ *       License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *       either express or implied. See the License for the specific language governing permissions
+ *       and limitations under the License.
+ * 
+ */
+package sonata.kernel.VimAdaptor.commons;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import sonata.kernel.VimAdaptor.commons.vnfd.VnfDescriptor;
+
+public class FunctionDeployPayload {
+
+  @JsonProperty("vim_uuid")
+  private String vimUuid;
+  @JsonProperty("service_instance_id")
+  private String serviceInstanceId;
+  @JsonProperty("vnfd")
+  private VnfDescriptor vnfd;
+
+  public String getVimUuid() {
+    return vimUuid;
+  }
+
+  public VnfDescriptor getVnfd() {
+    return vnfd;
+  }
+
+  public void setVimUuid(String vimUuid) {
+    this.vimUuid = vimUuid;
+  }
+
+  public void setVnfd(VnfDescriptor vnfd) {
+    this.vnfd = vnfd;
+  }
+
+  public String getServiceInstanceId() {
+    return serviceInstanceId;
+  }
+
+  public void setServiceInstanceId(String serviceInstanceId) {
+    this.serviceInstanceId = serviceInstanceId;
+  }
+
+
+
+}

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/FunctionDeployResponse.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/FunctionDeployResponse.java
@@ -28,36 +28,58 @@ package sonata.kernel.VimAdaptor.commons;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import sonata.kernel.VimAdaptor.commons.nsd.ServiceDescriptor;
-import sonata.kernel.VimAdaptor.commons.vnfd.VnfDescriptor;
-
 import java.util.ArrayList;
 
-public class DeployServiceData {
+public class FunctionDeployResponse {
 
-  @JsonProperty("vim_uuid")
+  private String instanceName;
+  private String instanceVimUuid;
   private String vimUuid;
-  private ServiceDescriptor nsd;
-  private ArrayList<VnfDescriptor> vnfds;
+  @JsonProperty("request_status")
+  private String requestStatus;
+  private VnfRecord vnfr;
+  private String errorCode;
 
-  public DeployServiceData() {
-    this.vnfds = new ArrayList<VnfDescriptor>();
+
+  public String getInstanceName() {
+    return instanceName;
   }
 
-  public void setServiceDescriptor(ServiceDescriptor descriptor) {
-    this.nsd = descriptor;
+  public String getInstanceVimUuid() {
+    return instanceVimUuid;
   }
 
-  public void addVnfDescriptor(VnfDescriptor descriptor) {
-    this.vnfds.add(descriptor);
+  public String getRequestStatus() {
+    return requestStatus;
   }
 
-  public ServiceDescriptor getNsd() {
-    return nsd;
+  public VnfRecord getVnfr() {
+    return vnfr;
   }
 
-  public ArrayList<VnfDescriptor> getVnfdList() {
-    return vnfds;
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+  public void setInstanceName(String instanceName) {
+    this.instanceName = instanceName;
+  }
+
+  public void setInstanceVimUuid(String instanceVimUuid) {
+    this.instanceVimUuid = instanceVimUuid;
+  }
+
+  public void setRequestStatus(String requestStatus) {
+    this.requestStatus = requestStatus;
+  }
+
+
+  public void setVnfrs(VnfRecord vnfr) {
+    this.vnfr = vnfr;
+  }
+
+  public void setErrorCode(String errorCode) {
+    this.errorCode = errorCode;
   }
 
   public String getVimUuid() {
@@ -68,13 +90,6 @@ public class DeployServiceData {
     this.vimUuid = vimUuid;
   }
 
-  public void setNsd(ServiceDescriptor nsd) {
-    this.nsd = nsd;
-  }
-
-  public void setVnfds(ArrayList<VnfDescriptor> vnfds) {
-    this.vnfds = vnfds;
-  }
 
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/NetworkConfigurePayload.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/NetworkConfigurePayload.java
@@ -1,0 +1,47 @@
+/**
+ * @author Dario Valocchi (Ph.D.)
+ * @mail d.valocchi@ucl.ac.uk
+ * 
+ *       Copyright 2016 [Dario Valocchi]
+ * 
+ *       Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *       except in compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *       Unless required by applicable law or agreed to in writing, software distributed under the
+ *       License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *       either express or implied. See the License for the specific language governing permissions
+ *       and limitations under the License.
+ * 
+ */
+package sonata.kernel.VimAdaptor.commons;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import sonata.kernel.VimAdaptor.commons.nsd.ForwardingGraph;
+
+public class NetworkConfigurePayload {
+
+  @JsonProperty("service_instance_id")
+  private String serviceInstanceId;
+  @JsonProperty("forwarding_graph")
+  private ForwardingGraph forwardingGraph;
+
+  public ForwardingGraph getForwardingGraph() {
+    return forwardingGraph;
+  }
+
+  public void setForwardingGraph(ForwardingGraph forwardingGraph) {
+    this.forwardingGraph = forwardingGraph;
+  }
+
+  public String getServiceInstanceId() {
+    return serviceInstanceId;
+  }
+
+  public void setServiceInstanceId(String serviceInstanceId) {
+    this.serviceInstanceId = serviceInstanceId;
+  }
+
+}

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/ServiceDeployPayload.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/ServiceDeployPayload.java
@@ -24,36 +24,57 @@
  * 
  */
 
-package sonata.kernel.VimAdaptor.wrapper;
+package sonata.kernel.VimAdaptor.commons;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class VlspWrapper extends ComputeWrapper {
+import sonata.kernel.VimAdaptor.commons.nsd.ServiceDescriptor;
+import sonata.kernel.VimAdaptor.commons.vnfd.VnfDescriptor;
 
-  public VlspWrapper(WrapperConfiguration config) {
-    super();
+import java.util.ArrayList;
+
+public class ServiceDeployPayload {
+
+  @JsonProperty("vim_uuid")
+  private String vimUuid;
+  private ServiceDescriptor nsd;
+  private ArrayList<VnfDescriptor> vnfds;
+
+  public ServiceDeployPayload() {
+    this.vnfds = new ArrayList<VnfDescriptor>();
   }
 
-  @Override
-  public boolean deployService(DeployServiceData data, String callSid) {
-    // TODO Auto-generated method stub
-    return false;
+  public void setServiceDescriptor(ServiceDescriptor descriptor) {
+    this.nsd = descriptor;
   }
 
-  public boolean removeService(String instanceUuid, String callSid) {
-    return false;
+  public void addVnfDescriptor(VnfDescriptor descriptor) {
+    this.vnfds.add(descriptor);
   }
 
-  @Override
-  public ResourceUtilisation getResourceUtilisation() {
-
-    ResourceUtilisation resources = new ResourceUtilisation();
-    resources.setTotCores(10);
-    resources.setUsedCores(0);
-    resources.setTotMemory(10000);
-    resources.setUsedMemory(0);
-
-    return resources;
+  public ServiceDescriptor getNsd() {
+    return nsd;
   }
+
+  public ArrayList<VnfDescriptor> getVnfdList() {
+    return vnfds;
+  }
+
+  public String getVimUuid() {
+    return vimUuid;
+  }
+
+  public void setVimUuid(String vimUuid) {
+    this.vimUuid = vimUuid;
+  }
+
+  public void setNsd(ServiceDescriptor nsd) {
+    this.nsd = nsd;
+  }
+
+  public void setVnfds(ArrayList<VnfDescriptor> vnfds) {
+    this.vnfds = vnfds;
+  }
+
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/ServiceDeployResponse.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/ServiceDeployResponse.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 
-public class DeployServiceResponse {
+public class ServiceDeployResponse {
 
   private String instanceName;
   private String instanceVimUuid;
@@ -41,7 +41,7 @@ public class DeployServiceResponse {
   private ArrayList<VnfRecord> vnfrs;
   private String errorCode;
 
-  public DeployServiceResponse() {
+  public ServiceDeployResponse() {
     this.vnfrs = new ArrayList<VnfRecord>();
   }
 

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/ServicePreparePayload.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/ServicePreparePayload.java
@@ -15,41 +15,35 @@
  *       and limitations under the License.
  * 
  */
-package sonata.kernel.VimAdaptor.wrapper.odlWrapper;
+package sonata.kernel.VimAdaptor.commons;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 
-public class OdlPayload {
+public class ServicePreparePayload {
 
-  /**
-   * @param string
-   * @param string2
-   * @param odlList2
-   */
-  public OdlPayload(String action, String instanceId, String inSeg, String outSeg,
-      ArrayList<OrderedMacAddress> odlList2) {
-    this.inputSegment = inSeg;
-    this.outputSegment = outSeg;
-    if (odlList2 != null) {
-      @SuppressWarnings("unchecked")
-      ArrayList<OrderedMacAddress> clone = (ArrayList<OrderedMacAddress>) odlList2.clone();
-      this.odlList = clone;
-    }
-    this.instanceId = instanceId;
-    this.action = action;
+  @JsonProperty("instance_id")
+  private String instanceId;
+  @JsonProperty("vim_list")
+  private ArrayList<String> vimList;
+
+  public String getInstanceId() {
+    return instanceId;
   }
 
-  @JsonProperty("action")
-  String action;
-  @JsonProperty("port_list")
-  ArrayList<OrderedMacAddress> odlList;
-  @JsonProperty("in_segment")
-  String inputSegment;
-  @JsonProperty("out_segment")
-  String outputSegment;
-  @JsonProperty("instance_id")
-  String instanceId;
+  public ArrayList<String> getVimList() {
+    return vimList;
+  }
+
+  public void setInstanceId(String instanceId) {
+    this.instanceId = instanceId;
+  }
+
+  public void setVimList(ArrayList<String> vimList) {
+    this.vimList = vimList;
+  }
+
+
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/nsd/ConnectionPoint.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/nsd/ConnectionPoint.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ConnectionPoint {
 
   public enum Interface {
-    INTERFACE("interface");
+    PUBLIC("public"),EXT("external"),INT("internal");
     private final String name;
 
     Interface(String name) {

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ComputeVimType.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ComputeVimType.java
@@ -27,7 +27,7 @@
 package sonata.kernel.VimAdaptor.wrapper;
 
 enum ComputeVimType {
-  VLSP("VLSP"), OPENSTACK("OpenStack"), OPENSTACKHEAT("Heat"), OPENMANO("OpenMANO"), MOCK(
+  OPENSTACK("OpenStack"), OPENSTACKHEAT("Heat"), OPENMANO("OpenMANO"), MOCK(
       "Mock"), OPENVIM("OpenVIM");
 
   private final String name;

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ComputeWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ComputeWrapper.java
@@ -26,6 +26,7 @@
 
 package sonata.kernel.VimAdaptor.wrapper;
 
+import sonata.kernel.VimAdaptor.commons.FunctionDeployPayload;
 import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 
 public abstract class ComputeWrapper extends AbstractWrapper implements Wrapper {
@@ -75,5 +76,13 @@ public abstract class ComputeWrapper extends AbstractWrapper implements Wrapper 
    * @return the ResourceUtilisation object representing the status of this VIM
    */
   public abstract ResourceUtilisation getResourceUtilisation();
+
+  /**
+   * Deploy a the VNF described in the payload in this compute VIM
+   * 
+   * @param data the payload of a Function.Deploy call
+   * @param sid the session ID for this Adaptor call.
+   */
+  public abstract void deployFunction(FunctionDeployPayload data, String sid);
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ComputeWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ComputeWrapper.java
@@ -26,7 +26,7 @@
 
 package sonata.kernel.VimAdaptor.wrapper;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 
 public abstract class ComputeWrapper extends AbstractWrapper implements Wrapper {
 
@@ -40,6 +40,15 @@ public abstract class ComputeWrapper extends AbstractWrapper implements Wrapper 
   }
 
   /**
+   * Prepare a service instance in this VIM for the given instance ID.
+   * 
+   * @param instanceId the ID of the instance used as reference for the prepared environment in the VIM
+   * 
+   * @return true if the remove process has started correctly, false otherwise
+   */
+  public abstract boolean prepareService(String instanceId) throws Exception;
+  
+  /**
    * Remove a service instance from this VIM.
    * 
    * @param data the payload containing the service descriptors and the metadata for this service
@@ -48,7 +57,7 @@ public abstract class ComputeWrapper extends AbstractWrapper implements Wrapper 
    * 
    * @return true if the remove process has started correctly, false otherwise
    */
-  public abstract boolean deployService(DeployServiceData data, String callSid) throws Exception;
+  public abstract boolean deployService(ServiceDeployPayload data, String callSid) throws Exception;
 
   /**
    * Remove a service instance from this VIM.

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/MockWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/MockWrapper.java
@@ -34,8 +34,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import org.slf4j.LoggerFactory;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
-import sonata.kernel.VimAdaptor.commons.DeployServiceResponse;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployResponse;
 import sonata.kernel.VimAdaptor.commons.ServiceRecord;
 import sonata.kernel.VimAdaptor.commons.Status;
 import sonata.kernel.VimAdaptor.commons.VduRecord;
@@ -51,7 +51,7 @@ public class MockWrapper extends ComputeWrapper implements Runnable {
    * suitable object with these fields, able to handle the API call asynchronously, generate a
    * response and update the observer
    */
-  private DeployServiceData data;
+  private ServiceDeployPayload data;
   private String sid;
 
   private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(MockWrapper.class);
@@ -67,7 +67,7 @@ public class MockWrapper extends ComputeWrapper implements Runnable {
   }
 
   @Override
-  public boolean deployService(DeployServiceData data, String callSid) {
+  public boolean deployService(ServiceDeployPayload data, String callSid) {
     this.data = data;
     this.sid = callSid;
     // This is a mock compute wrapper.
@@ -92,7 +92,7 @@ public class MockWrapper extends ComputeWrapper implements Runnable {
       Logger.error(e.getMessage(), e);
     }
     Logger.info("Service DEPLOYED. Creating response");
-    DeployServiceResponse response = new DeployServiceResponse();
+    ServiceDeployResponse response = new ServiceDeployResponse();
     response.setRequestStatus("DEPLOYED");;
     ServiceRecord sr = new ServiceRecord();
     sr.setStatus(Status.normal_operation);
@@ -161,6 +161,14 @@ public class MockWrapper extends ComputeWrapper implements Runnable {
     resources.setUsedMemory(0);
 
     return resources;
+  }
+
+  /* (non-Javadoc)
+   * @see sonata.kernel.VimAdaptor.wrapper.ComputeWrapper#prepareService(java.lang.String)
+   */
+  @Override
+  public boolean prepareService(String instanceId) {
+    return true;
   }
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/NetworkVimType.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/NetworkVimType.java
@@ -26,28 +26,17 @@
 
 package sonata.kernel.VimAdaptor.wrapper;
 
-import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
-import sonata.kernel.VimAdaptor.commons.heat.StackComposition;
+enum NetworkVimType {
+  OPENVSWITCH("ovs"), NETWORKMOCK("networkMock");
 
-public abstract class NetworkingWrapper extends AbstractWrapper implements Wrapper {
+  private final String name;
 
-
-
-  public NetworkingWrapper() {
-
-    this.setType("networking");
-
+  NetworkVimType(String name) {
+    this.name = name;
   }
 
-  /**
-   * Configure the SFC and networking aspects of the service
-   * 
-   * @param data the service deployment descriptors
-   * @param composition the composition of the deployed service
-   * @throws Exception
-   * 
-   */
-  public abstract void configureNetworking(ServiceDeployPayload data, StackComposition composition)
-      throws Exception;
-
+  @Override
+  public String toString() {
+    return this.name;
+  }
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/NetworkWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/NetworkWrapper.java
@@ -26,17 +26,28 @@
 
 package sonata.kernel.VimAdaptor.wrapper;
 
-enum NetworkingVimType {
-  OPENVSWITCH("ovs"), NETWORKMOCK("networkMock");
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
+import sonata.kernel.VimAdaptor.commons.heat.StackComposition;
 
-  private final String name;
+public abstract class NetworkWrapper extends AbstractWrapper implements Wrapper {
 
-  NetworkingVimType(String name) {
-    this.name = name;
+
+
+  public NetworkWrapper() {
+
+    this.setType("network");
+
   }
 
-  @Override
-  public String toString() {
-    return this.name;
-  }
+  /**
+   * Configure the SFC and networking aspects of the service
+   * 
+   * @param data the service deployment descriptors
+   * @param composition the composition of the deployed service
+   * @throws Exception
+   * 
+   */
+  public abstract void configureNetworking(ServiceDeployPayload data, StackComposition composition)
+      throws Exception;
+
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/NetworkingVimType.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/NetworkingVimType.java
@@ -27,7 +27,7 @@
 package sonata.kernel.VimAdaptor.wrapper;
 
 enum NetworkingVimType {
-  OPENDAYLIGHT("odl"), NETWORKMOCK("networkMock");
+  OPENVSWITCH("ovs"), NETWORKMOCK("networkMock");
 
   private final String name;
 

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/NetworkingWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/NetworkingWrapper.java
@@ -26,7 +26,7 @@
 
 package sonata.kernel.VimAdaptor.wrapper;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.heat.StackComposition;
 
 public abstract class NetworkingWrapper extends AbstractWrapper implements Wrapper {
@@ -47,7 +47,7 @@ public abstract class NetworkingWrapper extends AbstractWrapper implements Wrapp
    * @throws Exception
    * 
    */
-  public abstract void configureNetworking(DeployServiceData data, StackComposition composition)
+  public abstract void configureNetworking(ServiceDeployPayload data, StackComposition composition)
       throws Exception;
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/VimRepo.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/VimRepo.java
@@ -132,20 +132,27 @@ public class VimRepo {
         sql = "CREATE TABLE vim " + "(UUID TEXT PRIMARY KEY NOT NULL," + " TYPE TEXT NOT NULL,"
             + " VENDOR TEXT NOT NULL," + " ENDPOINT TEXT NOT NULL," + " USERNAME TEXT NOT NULL,"
             + " TENANT TEXT NOT NULL," + " TENANT_EXT_NET TEXT," + " TENANT_EXT_ROUTER TEXT,"
-            + " PASS TEXT," + " AUTHKEY TEXT);";
+            + " PASS TEXT," + " AUTHKEY TEXT" + ");";
         stmt.executeUpdate(sql);
-        sql = "CREATE TABLE instances " + "(" + "INSTANCE_UUID TEXT PRIMARY KEY NOT NULL,"
+        sql = "CREATE TABLE service_instances " + "(" + "INSTANCE_UUID TEXT NOT NULL,"
             + " VIM_INSTANCE_UUID TEXT NOT NULL," + " VIM_INSTANCE_NAME TEXT NOT NULL,"
-            + " VIM_UUID TEXT NOT NULL" + ");";
+            + " VIM_UUID TEXT NOT NULL,"
+            + " PRIMARY KEY (INSTANCE_UUID, VIM_UUID)" + ");";
         stmt.executeUpdate(sql);
-        sql = "CREATE TABLE link_vim " + "(COMPUTE_UUID TEXT PRIMARY KEY NOT NULL,"
-            + " NETWORKING_UUID TEXT NOT NULL);";
+        sql = "CREATE TABLE function_instances " + "(" + "INSTANCE_UUID TEXT PRIMARY KEY NOT NULL,"
+            + " SERVICE_INSTANCE_UUID TEXT NOT NULL," + " VIM_UUID TEXT NOT NULL,"
+            + " FOREIGN KEY (SERVICE_INSTANCE_UUID, VIM_UUID) REFERENCES service_instances(INSTANCE_UUID, VIM_UUID) ON DELETE CASCADE"
+            + ");";
+        stmt.executeUpdate(sql);
+        sql = "CREATE TABLE link_vim "
+            + "(COMPUTE_UUID TEXT NOT NULL REFERENCES vim(UUID) ON DELETE CASCADE,"
+            + " NETWORKING_UUID TEXT NOT NULL REFERENCES vim(UUID) ON DELETE CASCADE" + ");";
         stmt.executeUpdate(sql);
 
       }
 
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       errors = true;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -165,7 +172,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
       }
     }
     if (!errors) {
@@ -217,7 +224,7 @@ public class VimRepo {
       stmt.executeUpdate();
       connection.commit();
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = false;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -231,7 +238,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         out = false;
       }
     }
@@ -266,7 +273,7 @@ public class VimRepo {
       stmt.executeUpdate();
       connection.commit();
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = false;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);;
@@ -280,7 +287,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         out = false;
 
       }
@@ -332,7 +339,7 @@ public class VimRepo {
       stmt.executeUpdate(sql);
       connection.commit();
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = false;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -346,7 +353,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         out = false;
 
       }
@@ -414,7 +421,7 @@ public class VimRepo {
         output = null;
       }
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       output = null;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -431,7 +438,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         output = null;
 
       }
@@ -469,7 +476,7 @@ public class VimRepo {
       }
 
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = null;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -486,7 +493,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
 
       }
     }
@@ -522,7 +529,7 @@ public class VimRepo {
       stmt.executeUpdate();
       connection.commit();
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = false;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -536,7 +543,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         out = false;
       }
     }
@@ -603,7 +610,7 @@ public class VimRepo {
         output = null;
       }
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       output = null;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -620,7 +627,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         output = null;
 
       }
@@ -638,7 +645,7 @@ public class VimRepo {
    * @return the uuid used by the VIM to identify the service instance
    * 
    */
-  public String getServiceVimUuid(String instanceUuid) {
+  public String getServiceInstanceVimUuid(String instanceUuid) {
 
     String output = null;
 
@@ -654,8 +661,8 @@ public class VimRepo {
               prop.getProperty("user"), prop.getProperty("pass"));
       connection.setAutoCommit(false);
 
-      stmt = connection
-          .prepareStatement("SELECT VIM_INSTANCE_UUID FROM INSTANCES WHERE INSTANCE_UUID=?;");
+      stmt = connection.prepareStatement(
+          "SELECT VIM_INSTANCE_UUID FROM service_instances  WHERE INSTANCE_UUID=?;");
       stmt.setString(1, instanceUuid);
       rs = stmt.executeQuery();
 
@@ -667,7 +674,7 @@ public class VimRepo {
         output = null;
       }
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       output = null;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -684,7 +691,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         output = null;
 
       }
@@ -704,7 +711,7 @@ public class VimRepo {
    * @return the logical name used by the VIM to identify the service instance
    * 
    */
-  public String getServiceVimName(String instanceUuid) {
+  public String getServiceInstanceVimName(String instanceUuid) {
 
     String output = null;
 
@@ -720,8 +727,8 @@ public class VimRepo {
               prop.getProperty("user"), prop.getProperty("pass"));
       connection.setAutoCommit(false);
 
-      stmt = connection
-          .prepareStatement("SELECT VIM_INSTANCE_NAME FROM INSTANCES WHERE INSTANCE_UUID=?;");
+      stmt = connection.prepareStatement(
+          "SELECT VIM_INSTANCE_NAME FROM service_instances  WHERE INSTANCE_UUID=?;");
       stmt.setString(1, instanceUuid);
       rs = stmt.executeQuery();
 
@@ -733,7 +740,7 @@ public class VimRepo {
         output = null;
       }
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       output = null;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -750,7 +757,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         output = null;
 
       }
@@ -772,7 +779,7 @@ public class VimRepo {
    * 
    * @return true for process success
    */
-  public boolean writeInstanceEntry(String instanceUuid, String vimInstanceUuid,
+  public boolean writeServiceInstanceEntry(String instanceUuid, String vimInstanceUuid,
       String vimInstanceName, String vimUuid) {
     boolean out = true;
 
@@ -788,7 +795,7 @@ public class VimRepo {
       connection.setAutoCommit(false);
 
       String sql =
-          "INSERT INTO INSTANCES (INSTANCE_UUID, VIM_INSTANCE_UUID, VIM_INSTANCE_NAME,VIM_UUID) "
+          "INSERT INTO service_instances  (INSTANCE_UUID, VIM_INSTANCE_UUID, VIM_INSTANCE_NAME,VIM_UUID) "
               + "VALUES (?, ?, ?, ?);";
       stmt = connection.prepareStatement(sql);
       stmt.setString(1, instanceUuid);
@@ -798,7 +805,7 @@ public class VimRepo {
       stmt.executeUpdate();
       connection.commit();
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = false;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -812,7 +819,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         out = false;
       }
     }
@@ -833,7 +840,7 @@ public class VimRepo {
    * 
    * @return true for process success
    */
-  public boolean updateInstanceEntry(String instanceUuid, String vimInstanceUuid,
+  public boolean updateServiceInstanceEntry(String instanceUuid, String vimInstanceUuid,
       String vimInstanceName, String vimUuid) {
     boolean out = true;
 
@@ -848,7 +855,7 @@ public class VimRepo {
               prop.getProperty("user"), prop.getProperty("pass"));
       connection.setAutoCommit(false);
 
-      String sql = "UPDATE INSTANCES set (VIM_INSTANCE_UUID, VIM_INSTANCE_NAME, VIM_UUID) "
+      String sql = "UPDATE service_instances  set (VIM_INSTANCE_UUID, VIM_INSTANCE_NAME, VIM_UUID) "
           + "VALUES (?, ?, ?) WHERE INSTANCE_UUID=?;";
       stmt = connection.prepareStatement(sql);
       stmt.setString(1, vimInstanceUuid);
@@ -858,7 +865,7 @@ public class VimRepo {
       stmt.executeUpdate();
       connection.commit();
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = false;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -872,7 +879,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         out = false;
       }
     }
@@ -883,15 +890,14 @@ public class VimRepo {
     return out;
   }
 
-
   /**
-   * delete the instance record into the repository.
+   * delete the service instance record into the repository.
    * 
    * @param instanceUuid the uuid of the instance in the NSD
    * 
    * @return true for process success
    */
-  public boolean removeInstanceEntry(String instanceUuid) {
+  public boolean removeServiceInstanceEntry(String instanceUuid) {
     boolean out = true;
 
     Connection connection = null;
@@ -905,13 +911,13 @@ public class VimRepo {
               prop.getProperty("user"), prop.getProperty("pass"));
       connection.setAutoCommit(false);
 
-      String sql = "DELETE FROM INSTANCES WHERE INSTANCE_UUID=?;";
+      String sql = "DELETE FROM service_instances  WHERE INSTANCE_UUID=?;";
       stmt = connection.prepareStatement(sql);
       stmt.setString(1, instanceUuid);
       stmt.executeUpdate();
       connection.commit();
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = false;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -925,7 +931,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         out = false;
       }
     }
@@ -936,6 +942,254 @@ public class VimRepo {
     return out;
   }
 
+  /**
+   * write the function instance record into the repository.
+   * 
+   * @param functionInstanceUuid the uuid of the function instance
+   * @param serviceInstanceUuid the uuid of the service instance this function instance is part of.
+   * @param computeWrapperUuid the uuid of the NFVi-PoP this function is deployed in.
+   * 
+   * @return true for process success
+   */
+  public boolean writeFunctionInstanceEntry(String functionInstanceUuid, String serviceInstanceUuid,
+      String computeWrapperUuid) {
+    boolean out = true;
+
+    Connection connection = null;
+    PreparedStatement stmt = null;
+    try {
+      Class.forName("org.postgresql.Driver");
+      connection =
+          DriverManager.getConnection(
+              "jdbc:postgresql://" + prop.getProperty("repo_host") + ":"
+                  + prop.getProperty("repo_port") + "/" + "vimregistry",
+              prop.getProperty("user"), prop.getProperty("pass"));
+      connection.setAutoCommit(false);
+
+      String sql =
+          "INSERT INTO function_instances  (INSTANCE_UUID, SERVICE_INSTANCE_UUID, VIM_UUID) "
+              + "VALUES (?, ?, ?);";
+      stmt = connection.prepareStatement(sql);
+      stmt.setString(1, functionInstanceUuid);
+      stmt.setString(2, serviceInstanceUuid);
+      stmt.setString(3, computeWrapperUuid);
+      stmt.executeUpdate();
+      connection.commit();
+    } catch (SQLException e) {
+      Logger.error(e.getMessage());
+      out = false;
+    } catch (ClassNotFoundException e) {
+      Logger.error(e.getMessage(), e);
+      out = false;
+    } finally {
+      try {
+        if (stmt != null) {
+          stmt.close();
+        }
+        if (connection != null) {
+          connection.close();
+        }
+      } catch (SQLException e) {
+        Logger.error(e.getMessage());
+        out = false;
+      }
+    }
+    if (!out) {
+      Logger.info("Records created successfully");
+    }
+
+    return out;
+  }
+
+  /**
+   * Get the VIM UUID where the given VNF is deployed.
+   * 
+   * @param functionId the instance UUID of the VNF
+   * 
+   * @return the uuid of the VIM
+   * 
+   */
+  public String getComputeVimUuidByFunctionInstanceId(String functionId) {
+    String output = null;
+
+    Connection connection = null;
+    PreparedStatement stmt = null;
+    ResultSet rs = null;
+    try {
+      Class.forName("org.postgresql.Driver");
+      connection =
+          DriverManager.getConnection(
+              "jdbc:postgresql://" + prop.getProperty("repo_host") + ":"
+                  + prop.getProperty("repo_port") + "/" + "vimregistry",
+              prop.getProperty("user"), prop.getProperty("pass"));
+      connection.setAutoCommit(false);
+
+      stmt = connection
+          .prepareStatement("SELECT VIM_UUID FROM function_instances  WHERE INSTANCE_UUID=?;");
+      stmt.setString(1, functionId);
+      rs = stmt.executeQuery();
+
+      if (rs.next()) {
+
+        output = rs.getString("VIM_UUID");
+
+      } else {
+        output = null;
+      }
+    } catch (SQLException e) {
+      Logger.error(e.getMessage());
+      output = null;
+    } catch (ClassNotFoundException e) {
+      Logger.error(e.getMessage());
+      output = null;
+    } finally {
+      try {
+        if (stmt != null) {
+          stmt.close();
+        }
+        if (rs != null) {
+          rs.close();
+        }
+        if (connection != null) {
+          connection.close();
+        }
+      } catch (SQLException e) {
+        Logger.error(e.getMessage());
+        output = null;
+
+      }
+    }
+    if (output != null) {
+      Logger.info("Operation done successfully");
+    }
+    return output;
+  }
+  
+
+  /**
+   * Get the UUID used to reference the service in the scope of the VIM where given VNF is deployed.
+   * 
+   * @param functionId the instance UUID of the VNF
+   * 
+   * @return the uuid used in the VIM scope to reference the service
+   * 
+   */
+  public String getServiceInstanceVimUuidByFunction(String functionId) {
+    String output = null;
+    Connection connection = null;
+    PreparedStatement stmt = null;
+    ResultSet rs = null;
+    try {
+      Class.forName("org.postgresql.Driver");
+      connection =
+          DriverManager.getConnection(
+              "jdbc:postgresql://" + prop.getProperty("repo_host") + ":"
+                  + prop.getProperty("repo_port") + "/" + "vimregistry",
+              prop.getProperty("user"), prop.getProperty("pass"));
+      connection.setAutoCommit(false);
+
+      stmt = connection.prepareStatement(
+          "SELECT VIM_INSTANCE_UUID FROM service_instances AS s,function_instances AS f WHERE s.INSTANCE_UUID=f.SERVICE_INSTANCE_UUID AND s.VIM_UUID=f.VIM_UUID AND f.INSTANCE_UUID=?;");
+      stmt.setString(1, functionId);
+      rs = stmt.executeQuery();
+      if (rs.next()) {
+
+        output = rs.getString("VIM_INSTANCE_UUID");
+
+      } else {
+        output = null;
+      }
+    } catch (SQLException e) {
+      Logger.error(e.getMessage());
+      output = null;
+    } catch (ClassNotFoundException e) {
+      Logger.error(e.getMessage(), e);
+      output = null;
+    } finally {
+      try {
+        if (stmt != null) {
+          stmt.close();
+        }
+        if (rs != null) {
+          rs.close();
+        }
+        if (connection != null) {
+          connection.close();
+        }
+      } catch (SQLException e) {
+        Logger.error(e.getMessage());
+        output = null;
+
+      }
+    }
+    if (output != null) {
+      Logger.info("Operation done successfully");
+    }
+    return output;
+  }
+
+  /**
+   * Get the name used to reference the service in the in the scope of the VIM where given VNF is
+   * deployed.
+   * 
+   * @param functionId the instance UUID of the VNF
+   * 
+   * @return the mnemonic name used in the VIM scope to reference the service
+   * 
+   */
+  public String getServiceInstanceVimNameByFunction(String functionId) {
+    String output = null;
+    Connection connection = null;
+    PreparedStatement stmt = null;
+    ResultSet rs = null;
+    try {
+      Class.forName("org.postgresql.Driver");
+      connection =
+          DriverManager.getConnection(
+              "jdbc:postgresql://" + prop.getProperty("repo_host") + ":"
+                  + prop.getProperty("repo_port") + "/" + "vimregistry",
+              prop.getProperty("user"), prop.getProperty("pass"));
+      connection.setAutoCommit(false);
+
+      stmt = connection.prepareStatement(
+          "SELECT VIM_INSTANCE_NAME FROM service_instances AS s,function_instances AS f WHERE s.INSTANCE_UUID=f.SERVICE_INSTANCE_UUID AND f.INSTANCE_UUID=?;");
+      stmt.setString(1, functionId);
+      rs = stmt.executeQuery();
+      if (rs.next()) {
+
+        output = rs.getString("VIM_INSTANCE_NAME");
+
+      } else {
+        output = null;
+      }
+    } catch (SQLException e) {
+      Logger.error(e.getMessage());
+      output = null;
+    } catch (ClassNotFoundException e) {
+      Logger.error(e.getMessage(), e);
+      output = null;
+    } finally {
+      try {
+        if (stmt != null) {
+          stmt.close();
+        }
+        if (rs != null) {
+          rs.close();
+        }
+        if (connection != null) {
+          connection.close();
+        }
+      } catch (SQLException e) {
+        Logger.error(e.getMessage());
+        output = null;
+
+      }
+    }
+    if (output != null) {
+      Logger.info("Operation done successfully");
+    }
+    return output;
+  }
 
   /**
    * @param instanceUuid
@@ -957,7 +1211,8 @@ public class VimRepo {
               prop.getProperty("user"), prop.getProperty("pass"));
       connection.setAutoCommit(false);
 
-      stmt = connection.prepareStatement("SELECT VIM_UUID FROM INSTANCES WHERE INSTANCE_UUID=?;");
+      stmt = connection
+          .prepareStatement("SELECT VIM_UUID FROM service_instances  WHERE INSTANCE_UUID=?;");
       stmt.setString(1, instanceUuid);
       rs = stmt.executeQuery();
 
@@ -969,7 +1224,7 @@ public class VimRepo {
         output = null;
       }
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       output = null;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -986,7 +1241,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         output = null;
 
       }
@@ -1021,7 +1276,7 @@ public class VimRepo {
       stmt.executeUpdate();
       connection.commit();
     } catch (SQLException e) {
-      Logger.error(e.getMessage(), e);
+      Logger.error(e.getMessage());
       out = false;
     } catch (ClassNotFoundException e) {
       Logger.error(e.getMessage(), e);
@@ -1035,7 +1290,7 @@ public class VimRepo {
           connection.close();
         }
       } catch (SQLException e) {
-        Logger.error(e.getMessage(), e);
+        Logger.error(e.getMessage());
         out = false;
       }
     }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/VimRepo.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/VimRepo.java
@@ -502,7 +502,7 @@ public class VimRepo {
   }
 
   /**
-   * Write the association between NetworkingWrapper and ComputeWrapper.
+   * Write the association between NetworkWrapper and ComputeWrapper.
    * 
    * @param computeUuid the uuid of the compute wrapper
    * @param networkingUuid the uuid of the networking wrapper
@@ -555,7 +555,7 @@ public class VimRepo {
   }
 
   /**
-   * Get the NetworkingWrapper associated to the given computeVim.
+   * Get the NetworkWrapper associated to the given computeVim.
    * 
    * @param computeUuid the uuid of the computeVim
    * @return

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperBay.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperBay.java
@@ -170,6 +170,15 @@ public class WrapperBay {
     return "{\"status\":\"COMPLETED\"}";
   }
 
+  /**
+   * Return a generic Vim Wrapper for the given Vim UUID
+   * @param uuid
+   * @return
+   */
+  public Wrapper getWrapper(String uuid) {
+    return this.repository.readVimEntry(uuid).getVimWrapper();
+  }
+
 
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperBay.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperBay.java
@@ -136,12 +136,12 @@ public class WrapperBay {
    * @param computeVimRef
    * @return
    */
-  public String registerNetworkingWrapper(WrapperConfiguration config, String computeVimRef) {
+  public String registerNetworkWrapper(WrapperConfiguration config, String computeVimRef) {
     Wrapper newWrapper = WrapperFactory.createWrapper(config);
     String output = "";
     if (newWrapper == null) {
       output = "{\"status\":\"ERROR\",\"message:\"Cannot Attach To Vim\"}";
-    } else if (newWrapper.getType().equals("networking")) {
+    } else if (newWrapper.getType().equals("network")) {
       WrapperRecord record = new WrapperRecord(newWrapper, config, null);
       this.repository.writeVimEntry(config.getUuid(), record);
       this.repository.writeNetworkVimLink(computeVimRef, config.getUuid());

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperFactory.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperFactory.java
@@ -49,8 +49,8 @@ public class WrapperFactory {
     if (config.getWrapperType().equals("compute")) {
       output = createComputeWrapper(config);
     }
-    if (config.getWrapperType().equals("networking")) {
-      output = createNetworkingWrapper(config);
+    if (config.getWrapperType().equals("network")) {
+      output = createNetworkWrapper(config);
     }
     if (config.getWrapperType().equals("storage")) {
       output = createStorageWrapper(config);
@@ -78,11 +78,11 @@ public class WrapperFactory {
     return output;
   }
 
-  private static NetworkingWrapper createNetworkingWrapper(WrapperConfiguration config) {
-    NetworkingWrapper output = null;
-    if (config.getVimVendor().equals(NetworkingVimType.OPENVSWITCH.toString())) {
+  private static NetworkWrapper createNetworkWrapper(WrapperConfiguration config) {
+    NetworkWrapper output = null;
+    if (config.getVimVendor().equals(NetworkVimType.OPENVSWITCH.toString())) {
       output = new OvsWrapper(config);
-    } else if (config.getVimVendor().equals(NetworkingVimType.NETWORKMOCK.toString())) {
+    } else if (config.getVimVendor().equals(NetworkVimType.NETWORKMOCK.toString())) {
       output = new NetworkMockWrapper(config);
     }
     return output;

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperFactory.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperFactory.java
@@ -28,6 +28,7 @@ package sonata.kernel.VimAdaptor.wrapper;
 
 import org.slf4j.LoggerFactory;
 
+import sonata.kernel.VimAdaptor.wrapper.mock.ComputeMockWrapper;
 import sonata.kernel.VimAdaptor.wrapper.mock.NetworkMockWrapper;
 import sonata.kernel.VimAdaptor.wrapper.openstack.OpenStackHeatWrapper;
 import sonata.kernel.VimAdaptor.wrapper.ovsWrapper.OvsWrapper;
@@ -67,7 +68,7 @@ public class WrapperFactory {
     ComputeWrapper output = null;
 
     if (config.getVimVendor().equals(ComputeVimType.MOCK.toString())) {
-      output = new MockWrapper(config);
+      output = new ComputeMockWrapper(config);
     } else if (config.getVimVendor().equals(ComputeVimType.OPENSTACKHEAT.toString())) {
       output = new OpenStackHeatWrapper(config);
     }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperFactory.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/WrapperFactory.java
@@ -29,8 +29,8 @@ package sonata.kernel.VimAdaptor.wrapper;
 import org.slf4j.LoggerFactory;
 
 import sonata.kernel.VimAdaptor.wrapper.mock.NetworkMockWrapper;
-import sonata.kernel.VimAdaptor.wrapper.odlWrapper.OdlWrapper;
 import sonata.kernel.VimAdaptor.wrapper.openstack.OpenStackHeatWrapper;
+import sonata.kernel.VimAdaptor.wrapper.ovsWrapper.OvsWrapper;
 
 public class WrapperFactory {
 
@@ -66,9 +66,7 @@ public class WrapperFactory {
   private static ComputeWrapper createComputeWrapper(WrapperConfiguration config) {
     ComputeWrapper output = null;
 
-    if (config.getVimVendor().equals(ComputeVimType.VLSP.toString())) {
-      output = new VlspWrapper(config);
-    } else if (config.getVimVendor().equals(ComputeVimType.MOCK.toString())) {
+    if (config.getVimVendor().equals(ComputeVimType.MOCK.toString())) {
       output = new MockWrapper(config);
     } else if (config.getVimVendor().equals(ComputeVimType.OPENSTACKHEAT.toString())) {
       output = new OpenStackHeatWrapper(config);
@@ -81,8 +79,8 @@ public class WrapperFactory {
 
   private static NetworkingWrapper createNetworkingWrapper(WrapperConfiguration config) {
     NetworkingWrapper output = null;
-    if (config.getVimVendor().equals(NetworkingVimType.OPENDAYLIGHT.toString())) {
-      output = new OdlWrapper(config);
+    if (config.getVimVendor().equals(NetworkingVimType.OPENVSWITCH.toString())) {
+      output = new OvsWrapper(config);
     } else if (config.getVimVendor().equals(NetworkingVimType.NETWORKMOCK.toString())) {
       output = new NetworkMockWrapper(config);
     }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/mock/ComputeMockWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/mock/ComputeMockWrapper.java
@@ -24,7 +24,7 @@
  * 
  */
 
-package sonata.kernel.VimAdaptor.wrapper;
+package sonata.kernel.VimAdaptor.wrapper.mock;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import org.slf4j.LoggerFactory;
 
+import sonata.kernel.VimAdaptor.commons.FunctionDeployPayload;
 import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.ServiceDeployResponse;
 import sonata.kernel.VimAdaptor.commons.ServiceRecord;
@@ -42,9 +43,13 @@ import sonata.kernel.VimAdaptor.commons.VduRecord;
 import sonata.kernel.VimAdaptor.commons.VnfRecord;
 import sonata.kernel.VimAdaptor.commons.vnfd.VirtualDeploymentUnit;
 import sonata.kernel.VimAdaptor.commons.vnfd.VnfDescriptor;
+import sonata.kernel.VimAdaptor.wrapper.ComputeWrapper;
+import sonata.kernel.VimAdaptor.wrapper.ResourceUtilisation;
+import sonata.kernel.VimAdaptor.wrapper.WrapperConfiguration;
+import sonata.kernel.VimAdaptor.wrapper.WrapperStatusUpdate;
 
 
-public class MockWrapper extends ComputeWrapper implements Runnable {
+public class ComputeMockWrapper extends ComputeWrapper implements Runnable {
 
   /*
    * Utility fields to implement the mock response creation. A real wrapper should instantiate a
@@ -54,10 +59,10 @@ public class MockWrapper extends ComputeWrapper implements Runnable {
   private ServiceDeployPayload data;
   private String sid;
 
-  private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(MockWrapper.class);
+  private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(ComputeMockWrapper.class);
   private static final long THREAD_SLEEP = 1000;
 
-  public MockWrapper(WrapperConfiguration config) {
+  public ComputeMockWrapper(WrapperConfiguration config) {
     super();
   }
 
@@ -85,6 +90,7 @@ public class MockWrapper extends ComputeWrapper implements Runnable {
 
   @Override
   public void run() {
+    
     Logger.info("Deploying Service...");
     try {
       Thread.sleep(THREAD_SLEEP);
@@ -169,6 +175,15 @@ public class MockWrapper extends ComputeWrapper implements Runnable {
   @Override
   public boolean prepareService(String instanceId) {
     return true;
+  }
+
+  /* (non-Javadoc)
+   * @see sonata.kernel.VimAdaptor.wrapper.ComputeWrapper#deployFunction(sonata.kernel.VimAdaptor.commons.FunctionDeployPayload, java.lang.String)
+   */
+  @Override
+  public void deployFunction(FunctionDeployPayload data, String sid) {
+    // TODO Auto-generated method stub
+    
   }
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/mock/NetworkMockWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/mock/NetworkMockWrapper.java
@@ -1,6 +1,6 @@
 package sonata.kernel.VimAdaptor.wrapper.mock;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.heat.StackComposition;
 import sonata.kernel.VimAdaptor.wrapper.NetworkingWrapper;
 import sonata.kernel.VimAdaptor.wrapper.WrapperConfiguration;
@@ -16,7 +16,7 @@ public class NetworkMockWrapper extends NetworkingWrapper {
   }
 
   @Override
-  public void configureNetworking(DeployServiceData data, StackComposition composition)
+  public void configureNetworking(ServiceDeployPayload data, StackComposition composition)
       throws Exception {
     return;
   }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/mock/NetworkMockWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/mock/NetworkMockWrapper.java
@@ -2,13 +2,13 @@ package sonata.kernel.VimAdaptor.wrapper.mock;
 
 import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.heat.StackComposition;
-import sonata.kernel.VimAdaptor.wrapper.NetworkingWrapper;
+import sonata.kernel.VimAdaptor.wrapper.NetworkWrapper;
 import sonata.kernel.VimAdaptor.wrapper.WrapperConfiguration;
 
 /**
  * Created by nle5220 on 17.10.2016.
  */
-public class NetworkMockWrapper extends NetworkingWrapper {
+public class NetworkMockWrapper extends NetworkWrapper {
   private WrapperConfiguration config;
 
   public NetworkMockWrapper(WrapperConfiguration config) {

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/DeployServiceFsm.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/DeployServiceFsm.java
@@ -33,8 +33,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import org.slf4j.LoggerFactory;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
-import sonata.kernel.VimAdaptor.commons.DeployServiceResponse;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployResponse;
 import sonata.kernel.VimAdaptor.commons.ServiceRecord;
 import sonata.kernel.VimAdaptor.commons.Status;
 import sonata.kernel.VimAdaptor.commons.VduRecord;
@@ -59,7 +59,7 @@ import java.util.Hashtable;
 public class DeployServiceFsm implements Runnable {
 
   private String sid;
-  private DeployServiceData data;
+  private ServiceDeployPayload data;
   private OpenStackHeatWrapper wrapper;
   private OpenStackHeatClient client;
   private HeatTemplate stack;
@@ -77,7 +77,7 @@ public class DeployServiceFsm implements Runnable {
    * @param stack the HeatStack result of the translation
    */
   public DeployServiceFsm(OpenStackHeatWrapper wrapper, OpenStackHeatClient client, String sid,
-      DeployServiceData data, HeatTemplate stack) {
+      ServiceDeployPayload data, HeatTemplate stack) {
 
     this.wrapper = wrapper;
     this.client = client;
@@ -88,7 +88,7 @@ public class DeployServiceFsm implements Runnable {
 
   @Override
   public void run() {
-    DeployServiceResponse response = new DeployServiceResponse();
+    ServiceDeployResponse response = new ServiceDeployResponse();
 
     Logger.info("Deploying new stack");
     ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -274,7 +274,7 @@ public class DeployServiceFsm implements Runnable {
       Logger.info("Response created");
       // Logger.info("body");
 
-      WrapperBay.getInstance().getVimRepo().writeInstanceEntry(response.getNsr().getId(),
+      WrapperBay.getInstance().getVimRepo().writeServiceInstanceEntry(response.getNsr().getId(),
           response.getInstanceVimUuid(), response.getInstanceName(), data.getVimUuid());
 
       WrapperStatusUpdate update = new WrapperStatusUpdate(this.sid, "SUCCESS", body);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/DeployServiceFsm.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/DeployServiceFsm.java
@@ -49,7 +49,7 @@ import sonata.kernel.VimAdaptor.commons.nsd.ConnectionPointRecord;
 import sonata.kernel.VimAdaptor.commons.nsd.InterfaceRecord;
 import sonata.kernel.VimAdaptor.commons.vnfd.VirtualDeploymentUnit;
 import sonata.kernel.VimAdaptor.commons.vnfd.VnfDescriptor;
-import sonata.kernel.VimAdaptor.wrapper.NetworkingWrapper;
+import sonata.kernel.VimAdaptor.wrapper.NetworkWrapper;
 import sonata.kernel.VimAdaptor.wrapper.WrapperBay;
 import sonata.kernel.VimAdaptor.wrapper.WrapperStatusUpdate;
 
@@ -261,7 +261,7 @@ public class DeployServiceFsm implements Runnable {
         referenceVdur.addVnfcInstance(vnfc);
       }
 
-      NetworkingWrapper netVim = (NetworkingWrapper) WrapperBay.getInstance().getVimRepo()
+      NetworkWrapper netVim = (NetworkWrapper) WrapperBay.getInstance().getVimRepo()
           .getNetworkVim(this.data.getVimUuid()).getVimWrapper();
 
       netVim.configureNetworking(data, composition);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackHeatClient.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackHeatClient.java
@@ -87,7 +87,7 @@ public class OpenStackHeatClient {
   /**
    * Create stack.
    *
-   * @param stackName - usually service tenant
+   * @param stackName - the name of the stack
    * @param template - the content of the hot template that describes the file
    * @return - the uuid of the created stack, if the process failed the returned value is null
    */
@@ -113,6 +113,48 @@ public class OpenStackHeatClient {
     return uuid;
   }
 
+  public void updateStack(String stackName, String stackUuid, String template) {
+
+    Logger.info("Creating stack: " + stackName);
+    // Logger.debug("Template:\n" + template);
+
+    try {
+
+      String response = JavaStackUtils
+          .convertHttpResponseToString(javaStack.updateStack(stackName, stackUuid, template));
+
+    } catch (Exception e) {
+      Logger.error(
+          "Runtime error creating stack : " + stackName + " error message: " + e.getMessage());
+    }
+
+    return;
+  }
+
+  /**
+   * Get the heat template used to create the stack.
+   *
+   * @param stackName - the name of the stack in Heat
+   * @param stackUuid - the UUID of the stack in Heat
+   * @return - the HeatTemplate object representing the heat template.
+   */
+  public HeatTemplate getStackTemplate(String stackName, String stackUuid) {
+    HeatTemplate template = null;
+
+    try {
+      // template = JavaStackUtils.readFile("./test.yml");
+      mapper = new ObjectMapper();
+      String getStackTemplateResponse = JavaStackUtils
+          .convertHttpResponseToString(javaStack.getStackTemplate(stackName, stackUuid));
+      template = mapper.readValue(getStackTemplateResponse, HeatTemplate.class);
+
+    } catch (Exception e) {
+      Logger.error(
+          "Runtime error creating stack : " + stackName + " error message: " + e.getMessage());
+    }
+
+    return template;
+  }
 
   /**
    * Get the status of existing stack. Using Stack Name or Stack Id

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackHeatWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackHeatWrapper.java
@@ -28,6 +28,7 @@
 package sonata.kernel.VimAdaptor.wrapper.openstack;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -35,12 +36,22 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.slf4j.LoggerFactory;
 
 import sonata.kernel.VimAdaptor.commons.FunctionDeployPayload;
+import sonata.kernel.VimAdaptor.commons.FunctionDeployResponse;
 import sonata.kernel.VimAdaptor.commons.IpNetPool;
 import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
+import sonata.kernel.VimAdaptor.commons.Status;
+import sonata.kernel.VimAdaptor.commons.VduRecord;
+import sonata.kernel.VimAdaptor.commons.VnfRecord;
+import sonata.kernel.VimAdaptor.commons.VnfcInstance;
 import sonata.kernel.VimAdaptor.commons.heat.HeatModel;
+import sonata.kernel.VimAdaptor.commons.heat.HeatPort;
 import sonata.kernel.VimAdaptor.commons.heat.HeatResource;
+import sonata.kernel.VimAdaptor.commons.heat.HeatServer;
 import sonata.kernel.VimAdaptor.commons.heat.HeatTemplate;
+import sonata.kernel.VimAdaptor.commons.heat.StackComposition;
 import sonata.kernel.VimAdaptor.commons.nsd.ConnectionPoint;
+import sonata.kernel.VimAdaptor.commons.nsd.ConnectionPointRecord;
+import sonata.kernel.VimAdaptor.commons.nsd.InterfaceRecord;
 import sonata.kernel.VimAdaptor.commons.nsd.NetworkFunction;
 import sonata.kernel.VimAdaptor.commons.nsd.ServiceDescriptor;
 import sonata.kernel.VimAdaptor.commons.nsd.VirtualLink;
@@ -57,6 +68,7 @@ import sonata.kernel.VimAdaptor.wrapper.WrapperStatusUpdate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Hashtable;
 
 public class OpenStackHeatWrapper extends ComputeWrapper {
 
@@ -79,7 +91,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
 
   private HeatTemplate createInitStackTemplate(String instanceId) throws Exception {
     Logger.debug("Creating init stack template");
-    
+
     HeatModel model = new HeatModel();
     int subnetIndex = 0;
     ArrayList<String> subnets = myPool.reserveSubnets(instanceId, 2);
@@ -141,9 +153,9 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     model.addResource(dataSubnet);
 
     model.prepare();
-    
+
     HeatTemplate template = new HeatTemplate();
-    Logger.debug("Created " + model.getResources().size()+ " resurces.");
+    Logger.debug("Created " + model.getResources().size() + " resurces.");
     for (HeatResource resource : model.getResources()) {
       template.putResource(resource.getResourceName(), resource);
     }
@@ -651,11 +663,11 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
         port.setName(vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
         port.putProperty("name", vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
         HashMap<String, Object> netMap = new HashMap<String, Object>();
-        if (cp.getType().equals("internal")) {
+        if (cp.getType().equals(ConnectionPoint.Interface.INT)) {
           netMap.put("get_resource", "SonataService:data:net:" + instanceUuid);
-        } else if (cp.getType().equals("external")) {
+        } else if (cp.getType().equals(ConnectionPoint.Interface.EXT)) {
           netMap.put("get_resource", "SonataService:mgmt:net:" + instanceUuid);
-        } else if (cp.getType().equals("public")) {
+        } else if (cp.getType().equals(ConnectionPoint.Interface.PUBLIC)) {
           netMap.put("get_resource", "SonataService:mgmt:net:" + instanceUuid);
           publicPortNames.add(vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
         }
@@ -668,8 +680,8 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
         portMap.put("get_resource", vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
         n1.put("port", portMap);
         net.add(n1);
-
       }
+      server.putProperty("networks", net);
       model.addResource(server);
     }
 
@@ -730,44 +742,200 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     mapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
     mapper.setSerializationInclusion(Include.NON_NULL);
     Logger.info("Serializing updated stack...");
+    String stackString = null;
     try {
-      String stackString = mapper.writeValueAsString(template);
-      Logger.debug(stackString);
-      client.updateStack(stackName, stackUuid, stackString);
-
-      int counter = 0;
-      int wait = 1000;
-      int maxCounter = 10;
-      String status = null;
-      while ((status == null || !status.equals("CREATE_COMPLETE")
-          || !status.equals("CREATE_FAILED")) && counter < maxCounter) {
-        status = client.getStackStatus(stackName, stackUuid);
-        Logger.info("Status of stack " + stackUuid + ": " + status);
-        if (status != null
-            && (status.equals("CREATE_COMPLETE") || status.equals("CREATE_FAILED"))) {
-          break;
-        }
-        try {
-          Thread.sleep(wait);
-        } catch (InterruptedException e) {
-          Logger.error(e.getMessage(), e);
-        }
-        counter++;
-        wait *= 2;
-      }
-
-      if (status == null) {
-        Logger.error("unable to contact the VIM to check the update status");
-        return;
-      }
-      if (status.equals("CREATE_FAILED")) {
-        Logger.error("Heat Stack update process failed on the VIM side.");
-        return;
-      }
-
-    } catch (Exception e) {
-      // TODO: handle exception
+      stackString = mapper.writeValueAsString(template);
+    } catch (JsonProcessingException e) {
+      Logger.error(e.getMessage());
+      WrapperStatusUpdate update =
+          new WrapperStatusUpdate(sid, "ERROR", "Exception during VNF Deployment");
+      this.markAsChanged();
+      this.notifyObservers(update);
+      return;
     }
+    Logger.debug(stackString);
+    client.updateStack(stackName, stackUuid, stackString);
+
+    int counter = 0;
+    int wait = 1000;
+    int maxCounter = 10;
+    String status = null;
+    while ((status == null || !status.equals("UPDATE_COMPLETE") || !status.equals("UPDATE_FAILED"))
+        && counter < maxCounter) {
+      status = client.getStackStatus(stackName, stackUuid);
+      Logger.info("Status of stack " + stackUuid + ": " + status);
+      if (status != null && (status.equals("UPDATE_COMPLETE") || status.equals("UPDATE_FAILED"))) {
+        break;
+      }
+      try {
+        Thread.sleep(wait);
+      } catch (InterruptedException e) {
+        Logger.error(e.getMessage(), e);
+      }
+      counter++;
+      wait *= 2;
+    }
+
+    if (status == null) {
+      Logger.error("unable to contact the VIM to check the update status");
+      WrapperStatusUpdate update = new WrapperStatusUpdate(sid, "ERROR",
+          "Functiono deployment process failed. Can't get update status.");
+      this.markAsChanged();
+      this.notifyObservers(update);
+      return;
+    }
+    if (status.equals("UPDATE_FAILED")) {
+      Logger.error("Heat Stack update process failed on the VIM side.");
+      WrapperStatusUpdate update = new WrapperStatusUpdate(sid, "ERROR",
+          "Function deployment process failed on the VIM side.");
+      this.markAsChanged();
+      this.notifyObservers(update);
+      return;
+    }
+
+
+    counter = 0;
+    wait = 1000;
+    StackComposition composition = null;
+    while (composition == null && counter < maxCounter) {
+      Logger.info("Getting composition of stack " + stackUuid);
+      composition = client.getStackComposition(stackName, stackUuid);
+      try {
+        Thread.sleep(wait);
+      } catch (InterruptedException e) {
+        Logger.error(e.getMessage(), e);
+      }
+      counter++;
+      wait *= 2;
+    }
+
+    if (composition == null) {
+      Logger.error("unable to contact the VIM to get the stack composition");
+      WrapperStatusUpdate update =
+          new WrapperStatusUpdate(sid, "ERROR", "Unable to get updated stack composition");
+      this.markAsChanged();
+      this.notifyObservers(update);
+      return;
+    }
+
+    Logger.info("Creating function deploy response");
+    // Aux data structures for efficient mapping
+    Hashtable<String, VirtualDeploymentUnit> vduTable =
+        new Hashtable<String, VirtualDeploymentUnit>();
+    Hashtable<String, VduRecord> vdurTable = new Hashtable<String, VduRecord>();
+
+    // Create the response
+
+    FunctionDeployResponse response = new FunctionDeployResponse();
+    VnfDescriptor vnfd = data.getVnfd();
+    response.setRequestStatus("DEPLOYED");
+    response.setInstanceVimUuid(stackUuid);
+    response.setInstanceName(stackName);
+    response.setVimUuid(this.config.getUuid());
+
+    VnfRecord vnfr = new VnfRecord();
+    vnfr.setDescriptorVersion("vnfr-schema-01");
+    vnfr.setDescriptorReference(vnfd.getUuid());
+    // vnfr.setDescriptorReferenceName(vnf.getName());
+    // vnfr.setDescriptorReferenceVendor(vnf.getVendor());
+    // vnfr.setDescriptorReferenceVersion(vnf.getVersion());
+    vnfr.setStatus(Status.offline);
+    // TODO addresses are added next step
+    // vnfr.setVnfAddress("0.0.0.0");
+
+    vnfr.setId(vnfd.getInstanceUuid());
+    for (VirtualDeploymentUnit vdu : vnfd.getVirtualDeploymentUnits()) {
+      Logger.debug("Inspecting VDU " + vdu.getId());
+      VduRecord vdur = new VduRecord();
+      vdur.setId(vdu.getId());
+      vdur.setNumberOfInstances(1);
+      vdur.setVduReference(vnfd.getName() + ":" + vdu.getId());
+      vdur.setVmImage(vdu.getVmImage());
+      vdurTable.put(vdur.getVduReference(), vdur);
+      vnfr.addVdu(vdur);
+      Logger.debug("VDU table created: " + vduTable.toString());
+
+      HeatServer matchingServer = null;
+      for (HeatServer server : composition.getServers()) {
+        String[] identifiers = server.getServerName().split(":");
+        String vnfName = identifiers[0];
+        String vduName = identifiers[1];
+        String instanceId = identifiers[2];
+        if (vdu.getId().equals(vduName)) {
+          VnfcInstance vnfc = new VnfcInstance();
+          vnfc.setId(instanceId);
+          vnfc.setVimId(data.getVimUuid());
+          vnfc.setVcId(server.getServerId());
+          ArrayList<ConnectionPointRecord> cpRecords = new ArrayList<ConnectionPointRecord>();
+          for (ConnectionPoint cp : vdu.getConnectionPoints()) {
+            Logger.debug("Mapping CP " + cp.getId());
+            Logger.debug("Looking for port " + vnfd.getName() + ":" + cp.getId() + ":"
+                + data.getServiceInstanceId());
+            ConnectionPointRecord cpr = new ConnectionPointRecord();
+            cpr.setId(cp.getId());
+
+
+            // add each composition.ports information in the response. The IP, the netmask (and
+            // maybe
+            // MAC address)
+            boolean found = false;
+            for (HeatPort port : composition.getPorts()) {
+              Logger.debug("port " + port.getPortName());
+              if (port.getPortName()
+                  .equals(vnfd.getName() + ":" + cp.getId() + ":" + data.getServiceInstanceId())) {
+                found = true;
+                Logger.debug("Found! Filling VDUR parameters");
+                InterfaceRecord ip = new InterfaceRecord();
+                if (port.getFloatinIp() != null) {
+                  ip.setAddress(port.getFloatinIp());
+                  // Logger.info("Port:" + port.getPortName() + "- Addr: " +
+                  // port.getFloatinIp());
+                } else {
+                  ip.setAddress(port.getIpAddress());
+                  // Logger.info("Port:" + port.getPortName() + "- Addr: " +
+                  // port.getFloatinIp());
+                  ip.setNetmask("255.255.255.248");
+
+                }
+                cpr.setType(ip);
+                break;
+              }
+            }
+            if (!found) {
+              Logger.error("Can't find the VIM port that maps to this CP");
+            }
+            cpRecords.add(cpr);
+          }
+          vnfc.setConnectionPoints(cpRecords);
+          VduRecord referenceVdur = vdurTable.get(vnfd.getName() + ":" + vdu.getId());
+          referenceVdur.addVnfcInstance(vnfc);
+
+        }
+      }
+
+    }
+
+    response.setVnfrs(vnfr);
+    String body = null;
+    try {
+      body = mapper.writeValueAsString(response);
+    } catch (JsonProcessingException e) {
+      Logger.error(e.getMessage());
+      WrapperStatusUpdate update =
+          new WrapperStatusUpdate(sid, "ERROR", "Exception during VNF Deployment");
+      this.markAsChanged();
+      this.notifyObservers(update);
+      return;
+    }
+    Logger.info("Response created");
+    // Logger.info("body");
+
+    WrapperBay.getInstance().getVimRepo().writeFunctionInstanceEntry(vnfd.getInstanceUuid(),
+        data.getServiceInstanceId(), this.config.getUuid());
+    WrapperStatusUpdate update = new WrapperStatusUpdate(sid, "SUCCESS", body);
+    this.markAsChanged();
+    this.notifyObservers(update);
+
   }
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackHeatWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackHeatWrapper.java
@@ -34,9 +34,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import org.slf4j.LoggerFactory;
 
-import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
-import sonata.kernel.VimAdaptor.commons.ServicePreparePayload;
+import sonata.kernel.VimAdaptor.commons.FunctionDeployPayload;
 import sonata.kernel.VimAdaptor.commons.IpNetPool;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.heat.HeatModel;
 import sonata.kernel.VimAdaptor.commons.heat.HeatResource;
 import sonata.kernel.VimAdaptor.commons.heat.HeatTemplate;
@@ -272,8 +272,8 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
 
       }
 
-      WrapperBay.getInstance().getVimRepo().writeServiceInstanceEntry(instanceId, stackUuid, stackName,
-          this.config.getUuid());
+      WrapperBay.getInstance().getVimRepo().writeServiceInstanceEntry(instanceId, stackUuid,
+          stackName, this.config.getUuid());
 
     } catch (Exception e) {
       Logger.error("Error during stack creation.");
@@ -619,6 +619,36 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
       model.addResource(floatingIp);
     }
     model.prepare();
+    return model;
+  }
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see
+   * sonata.kernel.VimAdaptor.wrapper.ComputeWrapper#deployFunction(sonata.kernel.VimAdaptor.commons
+   * .FunctionDeployPayload, java.lang.String)
+   */
+  @Override
+  public void deployFunction(FunctionDeployPayload data, String sid) {
+    OpenStackHeatClient client = new OpenStackHeatClient(config.getVimEndpoint().toString(),
+        config.getAuthUserName(), config.getAuthPass(), config.getTenantName());
+
+    OpenStackNovaClient novaClient = new OpenStackNovaClient(config.getVimEndpoint().toString(),
+        config.getAuthUserName(), config.getAuthPass(), config.getTenantName());
+    ArrayList<Flavor> vimFlavors = novaClient.getFlavors();
+    Collections.sort(vimFlavors);
+    HeatModel stack;
+    try {
+      stack = translate(data.getVnfd(), vimFlavors);
+    } catch (Exception e) {
+      // TODO: handle exception
+    }
+  }
+  
+  private HeatModel translate(VnfDescriptor vnfd, ArrayList<Flavor> flavors){
+    HeatModel model = new HeatModel();
+    
     return model;
   }
 

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackNovaClient.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/OpenStackNovaClient.java
@@ -154,11 +154,11 @@ public class OpenStackNovaClient {
       mapper = new ObjectMapper();
       String listFlavors =
           JavaStackUtils.convertHttpResponseToString(javaStack.listComputeFlavors());
-      System.out.println(listFlavors);
+      //System.out.println(listFlavors);
       FlavorsData inputFlavors = mapper.readValue(listFlavors, FlavorsData.class);
-      System.out.println(inputFlavors.getFlavors());
+      //System.out.println(inputFlavors.getFlavors());
       for (FlavorProperties input_flavor : inputFlavors.getFlavors()) {
-        System.out.println(input_flavor.getId() + ": " + input_flavor.getName());
+        //System.out.println(input_flavor.getId() + ": " + input_flavor.getName());
 
         flavorName = input_flavor.getName();
         cpu = Integer.parseInt(input_flavor.getVcpus());

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/javastackclient/JavaStackCore.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/openstack/javastackclient/JavaStackCore.java
@@ -7,6 +7,7 @@ import org.apache.http.HttpVersion;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URIBuilder;
@@ -207,7 +208,7 @@ public class JavaStackCore {
 
     HttpClient httpClient = HttpClientBuilder.create().build();
     HttpResponseFactory factory = new DefaultHttpResponseFactory();
-    HttpPut updateStack = null;
+    HttpPatch updateStack = null;
     HttpResponse response = null;
 
     String jsonTemplate = JavaStackUtils.convertYamlToJson(template);
@@ -226,17 +227,24 @@ public class JavaStackCore {
           tenant_id, stackName, stackUuid));
 
       // Logger.debug(buildUrl.toString());
-      updateStack = new HttpPut(buildUrl.toString());
+      updateStack = new HttpPatch(buildUrl.toString());
       updateStack
           .setEntity(new StringEntity(modifiedObject.toString(), ContentType.APPLICATION_JSON));
       // Logger.debug(this.token_id);
       updateStack.addHeader(Constants.AUTHTOKEN_HEADER.toString(), this.token_id);
 
+      Logger.debug("Request: " + updateStack.toString());
+      Logger.debug("Request body: " + modifiedObject.toString());
+      
       response = httpClient.execute(updateStack);
       int statusCode = response.getStatusLine().getStatusCode();
       String responsePhrase = response.getStatusLine().getReasonPhrase();
 
-      if (statusCode != 201){
+      Logger.debug("Response: " + response.toString());
+      Logger.debug("Response body:");
+
+      
+      if (statusCode != 202){
         BufferedReader in = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
         String line=null;
         
@@ -244,7 +252,7 @@ public class JavaStackCore {
           Logger.debug(line);
       }
       
-      return (statusCode == 201)
+      return (statusCode == 202)
           ? response
           : factory.newHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, statusCode,
               responsePhrase + ". Create Failed with Status: " + statusCode), null);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OrderedMacAddress.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OrderedMacAddress.java
@@ -15,7 +15,7 @@
  *       and limitations under the License.
  * 
  */
-package sonata.kernel.VimAdaptor.wrapper.odlWrapper;
+package sonata.kernel.VimAdaptor.wrapper.ovsWrapper;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OvsPayload.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OvsPayload.java
@@ -1,0 +1,55 @@
+/**
+ * @author Dario Valocchi (Ph.D.)
+ * @mail d.valocchi@ucl.ac.uk
+ * 
+ *       Copyright 2016 [Dario Valocchi]
+ * 
+ *       Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *       except in compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *       Unless required by applicable law or agreed to in writing, software distributed under the
+ *       License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *       either express or implied. See the License for the specific language governing permissions
+ *       and limitations under the License.
+ * 
+ */
+package sonata.kernel.VimAdaptor.wrapper.ovsWrapper;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+
+public class OvsPayload {
+
+  /**
+   * @param string
+   * @param string2
+   * @param odlList2
+   */
+  public OvsPayload(String action, String instanceId, String inSeg, String outSeg,
+      ArrayList<OrderedMacAddress> odlList2) {
+    this.inputSegment = inSeg;
+    this.outputSegment = outSeg;
+    if (odlList2 != null) {
+      @SuppressWarnings("unchecked")
+      ArrayList<OrderedMacAddress> clone = (ArrayList<OrderedMacAddress>) odlList2.clone();
+      this.odlList = clone;
+    }
+    this.instanceId = instanceId;
+    this.action = action;
+  }
+
+  @JsonProperty("action")
+  String action;
+  @JsonProperty("port_list")
+  ArrayList<OrderedMacAddress> odlList;
+  @JsonProperty("in_segment")
+  String inputSegment;
+  @JsonProperty("out_segment")
+  String outputSegment;
+  @JsonProperty("instance_id")
+  String instanceId;
+
+}

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OvsPayload.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OvsPayload.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 
 public class OvsPayload {
-
+  
   /**
    * @param string
    * @param string2

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OvsWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OvsWrapper.java
@@ -15,7 +15,7 @@
  *       and limitations under the License.
  * 
  */
-package sonata.kernel.VimAdaptor.wrapper.odlWrapper;
+package sonata.kernel.VimAdaptor.wrapper.ovsWrapper;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.LoggerFactory;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.heat.HeatPort;
 import sonata.kernel.VimAdaptor.commons.heat.StackComposition;
 import sonata.kernel.VimAdaptor.commons.nsd.ForwardingGraph;
@@ -48,9 +48,9 @@ import java.util.HashMap;
 import java.util.Properties;
 
 
-public class OdlWrapper extends NetworkingWrapper {
+public class OvsWrapper extends NetworkingWrapper {
 
-  private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(OdlWrapper.class);
+  private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(OvsWrapper.class);
 
   private static final String ADAPTOR_SEGMENTS_CONF = "/adaptor/segments.conf";
 
@@ -61,13 +61,13 @@ public class OdlWrapper extends NetworkingWrapper {
    * 
    * @param config the configuration object of this wrapper.
    */
-  public OdlWrapper(WrapperConfiguration config) {
+  public OvsWrapper(WrapperConfiguration config) {
     super();
     this.config = config;
   }
 
   @Override
-  public void configureNetworking(DeployServiceData data, StackComposition composition)
+  public void configureNetworking(ServiceDeployPayload data, StackComposition composition)
       throws Exception {
     if (data.getNsd().getForwardingGraphs().size() <= 0)
       throw new Exception("No Forwarding Graph specified in the descriptor");
@@ -183,7 +183,7 @@ public class OdlWrapper extends NetworkingWrapper {
     segments.load(new FileReader(new File(ADAPTOR_SEGMENTS_CONF)));
 
     Collections.sort(odlList);
-    OdlPayload odlPayload = new OdlPayload("add", data.getNsd().getInstanceUuid(),
+    OvsPayload odlPayload = new OvsPayload("add", data.getNsd().getInstanceUuid(),
         segments.getProperty("in"), segments.getProperty("out"), odlList);
     ObjectMapper mapper = new ObjectMapper(new JsonFactory());
     mapper.setSerializationInclusion(Include.NON_NULL);
@@ -217,7 +217,7 @@ public class OdlWrapper extends NetworkingWrapper {
 
   public void deconfigureNetworking(String instanceId) throws Exception {
 
-    OdlPayload odlPayload = new OdlPayload("delete", instanceId, null, null, null);
+    OvsPayload odlPayload = new OvsPayload("delete", instanceId, null, null, null);
     ObjectMapper mapper = new ObjectMapper(new JsonFactory());
     mapper.setSerializationInclusion(Include.NON_NULL);
     // Logger.info(compositionString);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OvsWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/wrapper/ovsWrapper/OvsWrapper.java
@@ -33,7 +33,7 @@ import sonata.kernel.VimAdaptor.commons.nsd.ServiceDescriptor;
 import sonata.kernel.VimAdaptor.commons.vnfd.ConnectionPointReference;
 import sonata.kernel.VimAdaptor.commons.vnfd.VnfDescriptor;
 import sonata.kernel.VimAdaptor.commons.vnfd.VnfVirtualLink;
-import sonata.kernel.VimAdaptor.wrapper.NetworkingWrapper;
+import sonata.kernel.VimAdaptor.wrapper.NetworkWrapper;
 import sonata.kernel.VimAdaptor.wrapper.WrapperConfiguration;
 
 import java.io.File;
@@ -48,7 +48,7 @@ import java.util.HashMap;
 import java.util.Properties;
 
 
-public class OvsWrapper extends NetworkingWrapper {
+public class OvsWrapper extends NetworkWrapper {
 
   private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(OvsWrapper.class);
 

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/AdaptorTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/AdaptorTest.java
@@ -95,62 +95,6 @@ public class AdaptorTest implements MessageReceiver {
     Assert.assertTrue(core.getState().equals("STOPPED"));
   }
 
-  /**
-   * Crete an empty VLSP wrapper
-   * 
-   * @throws IOException
-   */
-  @Ignore
-  public void testCreateVLSPWrapper() throws InterruptedException, IOException {
-    String message =
-        "{\"wr_type\":\"compute\",\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"VLSP\",\"vim_address\":\"http://localhost:9999\",\"username\":\"Eve\",\"pass\":\"Operator\",\"tenant\":\"operator\"}";
-    String topic = "infrastructure.management.compute.add";
-    BlockingQueue<ServicePlatformMessage> muxQueue =
-        new LinkedBlockingQueue<ServicePlatformMessage>();
-    BlockingQueue<ServicePlatformMessage> dispatcherQueue =
-        new LinkedBlockingQueue<ServicePlatformMessage>();
-
-    TestProducer producer = new TestProducer(muxQueue, this);
-    ServicePlatformMessage addVimMessage = new ServicePlatformMessage(message, "application/json",
-        topic, UUID.randomUUID().toString(), topic);
-    consumer = new TestConsumer(dispatcherQueue);
-    AdaptorCore core = new AdaptorCore(muxQueue, dispatcherQueue, consumer, producer, 0.05);
-
-    core.start();
-
-    consumer.injectMessage(addVimMessage);
-    Thread.sleep(2000);
-    while (output == null)
-      synchronized (mon) {
-        mon.wait();
-      }
-
-    JSONTokener tokener = new JSONTokener(output);
-    JSONObject jsonObject = (JSONObject) tokener.nextValue();
-    String uuid = jsonObject.getString("uuid");
-    String status = jsonObject.getString("status");
-    Assert.assertTrue(status.equals("COMPLETED"));
-
-    output = null;
-    message = "{\"wr_type\":\"compute\",\"uuid\":\"" + uuid + "\"}";
-    topic = "infrastructure.management.compute.remove";
-    ServicePlatformMessage removeVimMessage = new ServicePlatformMessage(message,
-        "application/json", topic, UUID.randomUUID().toString(), topic);
-    consumer.injectMessage(removeVimMessage);
-
-    while (output == null) {
-      synchronized (mon) {
-        mon.wait(1000);
-      }
-    }
-
-    tokener = new JSONTokener(output);
-    jsonObject = (JSONObject) tokener.nextValue();
-    status = jsonObject.getString("status");
-    Assert.assertTrue(status.equals("COMPLETED"));
-    core.stop();
-    WrapperBay.getInstance().clear();
-  }
 
   /**
    * Create a Mock wrapper

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/AdaptorTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/AdaptorTest.java
@@ -104,7 +104,7 @@ public class AdaptorTest implements MessageReceiver {
   @Test
   public void testCreateMOCKWrapper() throws InterruptedException, IOException {
     String message =
-        "{\"wr_type\":\"compute\",\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"Mock\",\"vim_address\":\"http://localhost:9999\",\"username\":\"Eve\",\"pass\":\"Operator\",\"tenant\":\"operator\"}";
+        "{\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"Mock\",\"vim_address\":\"http://localhost:9999\",\"username\":\"Eve\",\"pass\":\"Operator\",\"tenant\":\"operator\"}";
     String topic = "infrastructure.management.compute.add";
     BlockingQueue<ServicePlatformMessage> muxQueue =
         new LinkedBlockingQueue<ServicePlatformMessage>();
@@ -134,7 +134,7 @@ public class AdaptorTest implements MessageReceiver {
     Assert.assertTrue(status.equals("COMPLETED"));
 
     output = null;
-    message = "{\"wr_type\":\"compute\",\"uuid\":\"" + uuid + "\"}";
+    message = "{\"uuid\":\"" + uuid + "\"}";
     topic = "infrastructure.management.compute.remove";
     ServicePlatformMessage removeVimMessage = new ServicePlatformMessage(message,
         "application/json", topic, UUID.randomUUID().toString(), topic);
@@ -183,7 +183,7 @@ public class AdaptorTest implements MessageReceiver {
 
     for (int i = 0; i < 3; i++) {
       String message =
-          "{\"wr_type\":\"compute\",\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"Mock\",\"vim_address\":\"http://vim"
+          "{\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"Mock\",\"vim_address\":\"http://vim"
               + i + ":9999\",\"username\":\"Eve\",\"pass\":\"Operator\",\"tenant\":\"operator\"}";
       ServicePlatformMessage addVimMessage = new ServicePlatformMessage(message, "application/json",
           topic, UUID.randomUUID().toString(), topic);
@@ -238,7 +238,7 @@ public class AdaptorTest implements MessageReceiver {
 
     for (String regUuid : vimUuid) {
       output = null;
-      String removeMessage = "{\"wr_type\":\"compute\",\"uuid\":\"" + regUuid + "\"}";
+      String removeMessage = "{\"uuid\":\"" + regUuid + "\"}";
       topic = "infrastructure.management.compute.remove";
       ServicePlatformMessage removeVimMessage = new ServicePlatformMessage(removeMessage,
           "application/json", topic, UUID.randomUUID().toString(), topic);

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/DeployServiceTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/DeployServiceTest.java
@@ -373,7 +373,7 @@ public class DeployServiceTest implements MessageReceiver {
    *
    * @throws Exception
    */
-  @Test
+  @Ignore
   public void testDeployServiceOpenStack() throws Exception {
 
     BlockingQueue<ServicePlatformMessage> muxQueue =
@@ -1090,7 +1090,7 @@ public class DeployServiceTest implements MessageReceiver {
       FunctionDeployPayload vnfPayload = new FunctionDeployPayload();
       vnfPayload.setVnfd(vnfd);
       vnfPayload.setVimUuid(computeWrUuid);
-
+      vnfPayload.setServiceInstanceId(data.getNsd().getInstanceUuid());
       body = mapper.writeValueAsString(vnfPayload);
 
       topic = "infrastructure.function.deploy";

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/DeployServiceTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/DeployServiceTest.java
@@ -196,7 +196,7 @@ public class DeployServiceTest implements MessageReceiver {
     }
 
     String message =
-        "{\"wr_type\":\"compute\",\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"Mock\",\"vim_address\":\"http://localhost:9999\",\"username\":\"Eve\",\"pass\":\"Operator\",\"tenant\":\"operator\"}";
+        "{\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"Mock\",\"vim_address\":\"http://localhost:9999\",\"username\":\"Eve\",\"pass\":\"Operator\",\"tenant\":\"operator\"}";
     String topic = "infrastructure.management.compute.add";
     ServicePlatformMessage addVimMessage = new ServicePlatformMessage(message, "application/json",
         topic, UUID.randomUUID().toString(), topic);
@@ -238,7 +238,7 @@ public class DeployServiceTest implements MessageReceiver {
       }
     }
     Assert.assertTrue(output.contains("OK"));
-    message = "{\"wr_type\":\"compute\",\"uuid\":\"" + wrUuid + "\"}";
+    message = "{\"uuid\":\"" + wrUuid + "\"}";
     topic = "infrastructure.management.compute.remove";
     ServicePlatformMessage removeVimMessage = new ServicePlatformMessage(message,
         "application/json", topic, UUID.randomUUID().toString(), topic);
@@ -294,7 +294,7 @@ public class DeployServiceTest implements MessageReceiver {
 
 
     String message =
-        "{\"wr_type\":\"compute\",\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"Mock\",\"vim_address\":\"http://localhost:9999\",\"username\":\"Eve\",\"pass\":\"Operator\",\"tenant\":\"op_sonata\"}";
+        "{\"tenant_ext_net\":\"ext-subnet\",\"tenant_ext_router\":\"ext-router\",\"vim_type\":\"Mock\",\"vim_address\":\"http://localhost:9999\",\"username\":\"Eve\",\"pass\":\"Operator\",\"tenant\":\"op_sonata\"}";
     String topic = "infrastructure.management.compute.add";
     ServicePlatformMessage addVimMessage = new ServicePlatformMessage(message, "application/json",
         topic, UUID.randomUUID().toString(), topic);
@@ -346,7 +346,7 @@ public class DeployServiceTest implements MessageReceiver {
     for (VnfRecord vnfr : response.getVnfrs())
       Assert.assertTrue(vnfr.getStatus() == Status.normal_operation);
     output = null;
-    message = "{\"wr_type\":\"compute\",\"uuid\":\"" + wrUuid + "\"}";
+    message = "{\"uuid\":\"" + wrUuid + "\"}";
     topic = "infrastructure.management.compute.remove";
     ServicePlatformMessage removeVimMessage = new ServicePlatformMessage(message,
         "application/json", topic, UUID.randomUUID().toString(), topic);
@@ -400,7 +400,7 @@ public class DeployServiceTest implements MessageReceiver {
     }
 
 
-    String addVimBody = "{\"wr_type\":\"compute\",\"vim_type\":\"Heat\", "
+    String addVimBody = "{\"vim_type\":\"Heat\", "
         + "\"tenant_ext_router\":\"4ac2b52e-8f6b-4af3-ad28-38ede9d71c83\", "
         + "\"tenant_ext_net\":\"cbc5a4fa-59ed-4ec1-ad2d-adb270e21693\","
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"admin\","
@@ -426,7 +426,7 @@ public class DeployServiceTest implements MessageReceiver {
 
 
     output = null;
-    String addNetVimBody = "{\"wr_type\":\"networking\",\"vim_type\":\"ovs\", "
+    String addNetVimBody = "{\"vim_type\":\"ovs\", "
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"operator\","
         + "\"pass\":\"apass\",\"tenant\":\"tenant\",\"compute_uuid\":\"" + computeWrUuid + "\"}";
     topic = "infrastructure.management.networking.add";
@@ -593,7 +593,7 @@ public class DeployServiceTest implements MessageReceiver {
     }
 
 
-    String addVimBody = "{\"wr_type\":\"compute\",\"vim_type\":\"Heat\", "
+    String addVimBody = "{\"vim_type\":\"Heat\", "
         + "\"tenant_ext_router\":\"4ac2b52e-8f6b-4af3-ad28-38ede9d71c83\", "
         + "\"tenant_ext_net\":\"cbc5a4fa-59ed-4ec1-ad2d-adb270e21693\","
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"admin\","
@@ -619,7 +619,7 @@ public class DeployServiceTest implements MessageReceiver {
 
 
     output = null;
-    String addNetVimBody = "{\"wr_type\":\"networking\",\"vim_type\":\"ovs\", "
+    String addNetVimBody = "{\"vim_type\":\"ovs\", "
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"operator\","
         + "\"pass\":\"apass\",\"tenant\":\"tenant\",\"compute_uuid\":\"" + computeWrUuid + "\"}";
     topic = "infrastructure.management.networking.add";
@@ -825,153 +825,6 @@ public class DeployServiceTest implements MessageReceiver {
   }
 
 
-  /**
-   *
-   * This Module test try to deploy the demo service with the OpenStack wrapper. The actual
-   * connection to OpenStack is mocked.
-   *
-   * @throws Exception
-   */
-  /*
-   * public void testDeployServiceMockStack() throws Exception {
-   *
-   * OpenStackHeatClient client = Mockito.mock(OpenStackHeatClient.class);
-   * Mockito.when(client.createStack(Matchers.anyString(),Matchers.anyString())).thenReturn(UUID.
-   * randomUUID().toString());
-   *
-   * Mockito.when(client.getStackStatus(Matchers.anyString(),
-   * Matchers.anyString())).thenReturn("CREATE_COMPLETE");
-   *
-   * Mockito.when(client.deleteStack(Matchers.anyString(),
-   * Matchers.anyString())).thenReturn("DELETED");
-   *
-   * StackComposition comp =
-   *
-   * Mockito.when(client.getStackComposition(Matchers.anyString(),
-   * Matchers.anyString())).thenReturn(comp);
-   *
-   * PowerMockito.whenNew(OpenStackHeatClient.class).withAnyArguments().thenReturn(client);
-   *
-   *
-   *
-   * BlockingQueue<ServicePlatformMessage> muxQueue = new
-   * LinkedBlockingQueue<ServicePlatformMessage>(); BlockingQueue<ServicePlatformMessage>
-   * dispatcherQueue = new LinkedBlockingQueue<ServicePlatformMessage>();
-   *
-   * TestProducer producer = new TestProducer(muxQueue, this); consumer = new
-   * TestConsumer(dispatcherQueue); AdaptorCore core = new AdaptorCore(muxQueue, dispatcherQueue,
-   * consumer, producer, 0.1);
-   *
-   * core.start(); int counter = 0;
-   *
-   * try { while (counter < 2) { synchronized (mon) { mon.wait(); if
-   * (lastHeartbeat.contains("RUNNING")) counter++; } } } catch (Exception e) { assertTrue(false); }
-   *
-   *
-   * String addVimBody=
-   * "{\"wr_type\":\"compute\",\"vim_type\":\"Heat\", \"tenant_ext_router\":\"20790da5-2dc1-4c7e-b9c3-a8d590517563\", \"tenant_ext_net\":\"decd89e2-1681-427e-ac24-6e9f1abb1715\",\"vim_address\":\"openstack.sonata-nfv.eu\",\"username\":\"op_sonata\",\"pass\":\"op_s0n@t@\",\"tenant\":\"op_sonata\"}"
-   * ; String topic = "infrastructure.management.compute.add"; ServicePlatformMessage addVimMessage
-   * = new ServicePlatformMessage(addVimBody, "application/json", topic,
-   * UUID.randomUUID().toString(), topic); consumer.injectMessage(addVimMessage);
-   * Thread.sleep(2000); while (output == null) synchronized (mon) { mon.wait(1000); }
-   *
-   * JSONTokener tokener = new JSONTokener(output); JSONObject jsonObject = (JSONObject)
-   * tokener.nextValue(); String status = jsonObject.getString("status"); String wrUuid =
-   * jsonObject.getString("uuid"); assertTrue(status.equals("COMPLETED"));
-   * System.out.println("OenStack Wrapper added, with uuid: " + wrUuid);
-   *
-   * output = null; String baseInstanceUuid = data.getNsd().getInstanceUuid();
-   * data.setVimUuid(wrUuid); data.getNsd().setInstanceUuid(baseInstanceUuid + "-01");
-   *
-   * String body = mapper.writeValueAsString(data);
-   *
-   * topic = "infrastructure.service.deploy"; ServicePlatformMessage deployServiceMessage = new
-   * ServicePlatformMessage(body, "application/x-yaml", topic, UUID.randomUUID().toString(), topic);
-   *
-   * consumer.injectMessage(deployServiceMessage);
-   *
-   * Thread.sleep(2000); while (output == null) synchronized (mon) { mon.wait(1000); }
-   * assertNotNull(output); int retry = 0; int maxRetry = 60; while (output.contains("heartbeat") ||
-   * output.contains("Vim Added") && retry < maxRetry) synchronized (mon) { mon.wait(1000); retry++;
-   * }
-   *
-   * System.out.println("ServiceDeployResponse: "); System.out.println(output);
-   * assertTrue("No Deploy service response received", retry < maxRetry); ServiceDeployResponse
-   * response = mapper.readValue(output, ServiceDeployResponse.class);
-   * assertTrue(response.getRequestStatus().equals("DEPLOYED"));
-   * assertTrue(response.getNsr().getStatus() == Status.offline);
-   *
-   * for (VnfRecord vnfr : response.getVnfrs()) assertTrue(vnfr.getStatus() == Status.offline);
-   *
-   *
-   * // Deploy a second instance of the same service
-   *
-   * data.getNsd().setInstanceUuid(baseInstanceUuid + "-02"); output = null;
-   *
-   * body = mapper.writeValueAsString(data);
-   *
-   * topic = "infrastructure.service.deploy"; deployServiceMessage = new
-   * ServicePlatformMessage(body, "application/x-yaml", topic, UUID.randomUUID().toString(), topic);
-   *
-   * consumer.injectMessage(deployServiceMessage);
-   *
-   * Thread.sleep(2000); while (output == null) synchronized (mon) { mon.wait(1000); }
-   * assertNotNull(output); retry = 0; while (output.contains("heartbeat") ||
-   * output.contains("Vim Added") && retry < maxRetry) synchronized (mon) { mon.wait(1000); retry++;
-   * }
-   *
-   * System.out.println("ServiceDeployResponse: "); System.out.println(output);
-   * assertTrue("No Deploy service response received", retry < maxRetry); response =
-   * mapper.readValue(output, ServiceDeployResponse.class);
-   * assertTrue(response.getRequestStatus().equals("DEPLOYED"));
-   * assertTrue(response.getNsr().getStatus() == Status.offline); for (VnfRecord vnfr :
-   * response.getVnfrs()) assertTrue(vnfr.getStatus() == Status.offline);
-   *
-   *
-   * // // Clean the OpenStack tenant from the stack // OpenStackHeatClient client = // new
-   * OpenStackHeatClient("143.233.127.3", "op_sonata", "op_s0n@t@", "op_sonata"); // String
-   * stackName = response.getInstanceName(); // // String deleteStatus =
-   * client.deleteStack(stackName, response.getInstanceVimUuid()); //
-   * assertNotNull("Failed to delete stack", deleteStatus); // // if (deleteStatus != null) { //
-   * System.out.println("status of deleted stack " + stackName + " is " + deleteStatus); //
-   * assertEquals("DELETED", deleteStatus); // }
-   *
-   *
-   * // Service removal output = null; String instanceUuid = baseInstanceUuid + "-01"; String
-   * message = "{\"instance_uuid\":\"" + instanceUuid + "\",\"vim_uuid\":\"" + wrUuid + "\"}"; topic
-   * = "infrastructure.service.remove"; ServicePlatformMessage removeInstanceMessage = new
-   * ServicePlatformMessage(message, "application/json", topic, UUID.randomUUID().toString(),
-   * topic); consumer.injectMessage(removeInstanceMessage);
-   *
-   * while (output == null) { synchronized (mon) { mon.wait(2000); System.out.println(output); } }
-   * System.out.println(output); tokener = new JSONTokener(output); jsonObject = (JSONObject)
-   * tokener.nextValue(); status = jsonObject.getString("request_status");
-   * assertTrue("Adapter returned an unexpected status: " + status, status.equals("SUCCESS"));
-   *
-   * output = null; instanceUuid = baseInstanceUuid + "-02"; message = "{\"instance_uuid\":\"" +
-   * instanceUuid + "\",\"vim_uuid\":\"" + wrUuid + "\"}"; topic = "infrastructure.service.remove";
-   * removeInstanceMessage = new ServicePlatformMessage(message, "application/json", topic,
-   * UUID.randomUUID().toString(), topic); consumer.injectMessage(removeInstanceMessage);
-   *
-   * while (output == null) { synchronized (mon) { mon.wait(2000); System.out.println(output); } }
-   * System.out.println(output); tokener = new JSONTokener(output); jsonObject = (JSONObject)
-   * tokener.nextValue(); status = jsonObject.getString("request_status");
-   * assertTrue("Adapter returned an unexpected status: " + status, status.equals("SUCCESS"));
-   *
-   *
-   *
-   * output = null; message = "{\"wr_type\":\"compute\",\"uuid\":\"" + wrUuid + "\"}"; topic =
-   * "infrastructure.management.compute.remove"; ServicePlatformMessage removeVimMessage = new
-   * ServicePlatformMessage(message, "application/json", topic, UUID.randomUUID().toString(),
-   * topic); consumer.injectMessage(removeVimMessage);
-   *
-   * while (output == null) { synchronized (mon) { mon.wait(1000); } } System.out.println(output);
-   * tokener = new JSONTokener(output); jsonObject = (JSONObject) tokener.nextValue(); status =
-   * jsonObject.getString("status"); assertTrue(status.equals("COMPLETED")); core.stop();
-   *
-   * }
-   */
-
   @Test
   public void testDeployServiceIncremental() throws Exception {
     BlockingQueue<ServicePlatformMessage> muxQueue =
@@ -1024,7 +877,7 @@ public class DeployServiceTest implements MessageReceiver {
 
 
     output = null;
-    String addNetVimBody = "{\"wr_type\":\"networking\",\"vim_type\":\"ovs\", "
+    String addNetVimBody = "{\"vim_type\":\"ovs\", "
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"operator\","
         + "\"pass\":\"apass\",\"tenant\":\"tenant\",\"compute_uuid\":\"" + computeWrUuid + "\"}";
     topic = "infrastructure.management.networking.add";
@@ -1081,12 +934,13 @@ public class DeployServiceTest implements MessageReceiver {
         status.equals("COMPLETED"));
     System.out.println("Service " + payload.getInstanceId() + " ready for deployment");
 
-    output = null;
 
     // Send a VNF instantiation request for each VNFD linked by the NSD
 
     for (VnfDescriptor vnfd : data.getVnfdList()) {
 
+      output = null;
+      
       FunctionDeployPayload vnfPayload = new FunctionDeployPayload();
       vnfPayload.setVnfd(vnfd);
       vnfPayload.setVimUuid(computeWrUuid);
@@ -1107,11 +961,12 @@ public class DeployServiceTest implements MessageReceiver {
       Assert.assertNotNull(output);
       int retry = 0;
       int maxRetry = 60;
-      while (output.contains("heartbeat") || output.contains("Vim Added") && retry < maxRetry)
+      while (output.contains("heartbeat") || output.contains("Vim Added") && retry < maxRetry){
         synchronized (mon) {
           mon.wait(1000);
           retry++;
         }
+      }
 
       System.out.println("FunctionDeployResponse: ");
       System.out.println(output);
@@ -1124,8 +979,6 @@ public class DeployServiceTest implements MessageReceiver {
     // Finally configure Networking in each NFVi-PoP (VIMs)
 
     output = null;
-
-    // Prepare the system for a service deployment
 
     NetworkConfigurePayload netPayload = new NetworkConfigurePayload();
     netPayload.setForwardingGraph(data.getNsd().getForwardingGraphs().get(0));
@@ -1145,6 +998,7 @@ public class DeployServiceTest implements MessageReceiver {
         mon.wait(1000);
       }
 
+    System.out.println(output);
     tokener = new JSONTokener(output);
     jsonObject = (JSONObject) tokener.nextValue();
     status = null;
@@ -1153,8 +1007,70 @@ public class DeployServiceTest implements MessageReceiver {
         status.equals("COMPLETED"));
     System.out.println(
         "Service " + payload.getInstanceId() + " deployed and configured in selected VIM(s)");
-
+    
+    //Clean everything:
+    //1. De-configure SFC
+    //2. Remove Service
+    // Service removal (Still the old way)
     output = null;
+    String instanceUuid = data.getNsd().getInstanceUuid();
+    message = "{\"instance_uuid\":\"" + instanceUuid + "\"}";
+    topic = "infrastructure.service.remove";
+    ServicePlatformMessage removeInstanceMessage = new ServicePlatformMessage(message,
+        "application/json", topic, UUID.randomUUID().toString(), topic);
+    consumer.injectMessage(removeInstanceMessage);
+
+    while (output == null) {
+      synchronized (mon) {
+        mon.wait(2000);
+        System.out.println(output);
+      }
+    }
+    System.out.println(output);
+    tokener = new JSONTokener(output);
+    jsonObject = (JSONObject) tokener.nextValue();
+    status = jsonObject.getString("request_status");
+    Assert.assertTrue("Adapter returned an unexpected status: " + status, status.equals("SUCCESS"));
+    
+    //3. De-register VIMs.
+    
+    output = null;
+    message = "{\"wr_type\":\"compute\",\"uuid\":\"" + computeWrUuid + "\"}";
+    topic = "infrastructure.management.compute.remove";
+    ServicePlatformMessage removeVimMessage = new ServicePlatformMessage(message,
+        "application/json", topic, UUID.randomUUID().toString(), topic);
+    consumer.injectMessage(removeVimMessage);
+
+    while (output == null) {
+      synchronized (mon) {
+        mon.wait(1000);
+      }
+    }
+    System.out.println(output);
+    tokener = new JSONTokener(output);
+    jsonObject = (JSONObject) tokener.nextValue();
+    status = jsonObject.getString("status");
+    Assert.assertTrue(status.equals("COMPLETED"));
+    output = null;
+    message = "{\"wr_type\":\"network\",\"uuid\":\"" + netWrUuid + "\"}";
+    topic = "infrastructure.management.compute.remove";
+    ServicePlatformMessage removeNetVimMessage = new ServicePlatformMessage(message,
+        "application/json", topic, UUID.randomUUID().toString(), topic);
+    consumer.injectMessage(removeNetVimMessage);
+
+    while (output == null) {
+      synchronized (mon) {
+        mon.wait(1000);
+      }
+    }
+    System.out.println(output);
+    tokener = new JSONTokener(output);
+    jsonObject = (JSONObject) tokener.nextValue();
+    status = jsonObject.getString("status");
+    Assert.assertTrue(status.equals("COMPLETED"));
+
+    core.stop();  
+    
 
   }
 

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/DeployServiceTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/DeployServiceTest.java
@@ -429,7 +429,7 @@ public class DeployServiceTest implements MessageReceiver {
     String addNetVimBody = "{\"vim_type\":\"ovs\", "
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"operator\","
         + "\"pass\":\"apass\",\"tenant\":\"tenant\",\"compute_uuid\":\"" + computeWrUuid + "\"}";
-    topic = "infrastructure.management.networking.add";
+    topic = "infrastructure.management.network.add";
     ServicePlatformMessage addNetVimMessage = new ServicePlatformMessage(addNetVimBody,
         "application/json", topic, UUID.randomUUID().toString(), topic);
     consumer.injectMessage(addNetVimMessage);
@@ -622,7 +622,7 @@ public class DeployServiceTest implements MessageReceiver {
     String addNetVimBody = "{\"vim_type\":\"ovs\", "
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"operator\","
         + "\"pass\":\"apass\",\"tenant\":\"tenant\",\"compute_uuid\":\"" + computeWrUuid + "\"}";
-    topic = "infrastructure.management.networking.add";
+    topic = "infrastructure.management.network.add";
     ServicePlatformMessage addNetVimMessage = new ServicePlatformMessage(addNetVimBody,
         "application/json", topic, UUID.randomUUID().toString(), topic);
     consumer.injectMessage(addNetVimMessage);
@@ -880,7 +880,7 @@ public class DeployServiceTest implements MessageReceiver {
     String addNetVimBody = "{\"vim_type\":\"ovs\", "
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"operator\","
         + "\"pass\":\"apass\",\"tenant\":\"tenant\",\"compute_uuid\":\"" + computeWrUuid + "\"}";
-    topic = "infrastructure.management.networking.add";
+    topic = "infrastructure.management.network.add";
     ServicePlatformMessage addNetVimMessage = new ServicePlatformMessage(addNetVimBody,
         "application/json", topic, UUID.randomUUID().toString(), topic);
     consumer.injectMessage(addNetVimMessage);
@@ -982,6 +982,7 @@ public class DeployServiceTest implements MessageReceiver {
 
     NetworkConfigurePayload netPayload = new NetworkConfigurePayload();
     netPayload.setForwardingGraph(data.getNsd().getForwardingGraphs().get(0));
+    netPayload.setServiceInstanceId(data.getNsd().getInstanceUuid());
     
 
     body = mapper.writeValueAsString(netPayload);
@@ -1035,7 +1036,7 @@ public class DeployServiceTest implements MessageReceiver {
     //3. De-register VIMs.
     
     output = null;
-    message = "{\"wr_type\":\"compute\",\"uuid\":\"" + computeWrUuid + "\"}";
+    message = "{\"uuid\":\"" + computeWrUuid + "\"}";
     topic = "infrastructure.management.compute.remove";
     ServicePlatformMessage removeVimMessage = new ServicePlatformMessage(message,
         "application/json", topic, UUID.randomUUID().toString(), topic);
@@ -1051,9 +1052,10 @@ public class DeployServiceTest implements MessageReceiver {
     jsonObject = (JSONObject) tokener.nextValue();
     status = jsonObject.getString("status");
     Assert.assertTrue(status.equals("COMPLETED"));
+    
     output = null;
-    message = "{\"wr_type\":\"network\",\"uuid\":\"" + netWrUuid + "\"}";
-    topic = "infrastructure.management.compute.remove";
+    message = "{\"uuid\":\"" + netWrUuid + "\"}";
+    topic = "infrastructure.management.network.remove";
     ServicePlatformMessage removeNetVimMessage = new ServicePlatformMessage(message,
         "application/json", topic, UUID.randomUUID().toString(), topic);
     consumer.injectMessage(removeNetVimMessage);

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/DeployServiceTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/DeployServiceTest.java
@@ -373,7 +373,7 @@ public class DeployServiceTest implements MessageReceiver {
    *
    * @throws Exception
    */
-  @Ignore
+  @Test
   public void testDeployServiceOpenStack() throws Exception {
 
     BlockingQueue<ServicePlatformMessage> muxQueue =
@@ -972,7 +972,7 @@ public class DeployServiceTest implements MessageReceiver {
    * }
    */
 
-  @Ignore
+  @Test
   public void testDeployServiceIncremental() throws Exception {
     BlockingQueue<ServicePlatformMessage> muxQueue =
         new LinkedBlockingQueue<ServicePlatformMessage>();
@@ -1056,7 +1056,7 @@ public class DeployServiceTest implements MessageReceiver {
     payload.setInstanceId(data.getNsd().getInstanceUuid());
     ArrayList<String> vims = new ArrayList<String>();
     vims.add(computeWrUuid);
-
+    payload.setVimList(vims);
 
     String body = mapper.writeValueAsString(payload);
 

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/HeatTemplateTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/HeatTemplateTest.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.heat.HeatResource;
 import sonata.kernel.VimAdaptor.commons.heat.HeatTemplate;
 import sonata.kernel.VimAdaptor.commons.nsd.ServiceDescriptor;
@@ -102,7 +102,7 @@ public class HeatTemplateTest {
 
 
 
-    DeployServiceData data = new DeployServiceData();
+    ServiceDeployPayload data = new ServiceDeployPayload();
     data.setServiceDescriptor(sd);
     data.addVnfDescriptor(vnfd1);
     data.addVnfDescriptor(vnfd2);

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/ServiceDescriptorTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/ServiceDescriptorTest.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.nsd.ServiceDescriptor;
 import sonata.kernel.VimAdaptor.commons.vnfd.Unit;
 import sonata.kernel.VimAdaptor.commons.vnfd.UnitDeserializer;
@@ -98,7 +98,7 @@ public class ServiceDescriptorTest {
       bodyBuilder.append(line + "\n\r");
     vnfd2 = mapper.readValue(bodyBuilder.toString(), VnfDescriptor.class);
 
-    DeployServiceData data = new DeployServiceData();
+    ServiceDeployPayload data = new ServiceDeployPayload();
     data.setServiceDescriptor(sd);
     data.addVnfDescriptor(vnfd1);
     data.addVnfDescriptor(vnfd2);

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/VimRepoTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/VimRepoTest.java
@@ -30,10 +30,10 @@ package sonata.kernel.VimAdaptor;
 import org.junit.Assert;
 import org.junit.Test;
 
-import sonata.kernel.VimAdaptor.wrapper.MockWrapper;
 import sonata.kernel.VimAdaptor.wrapper.VimRepo;
 import sonata.kernel.VimAdaptor.wrapper.WrapperConfiguration;
 import sonata.kernel.VimAdaptor.wrapper.WrapperRecord;
+import sonata.kernel.VimAdaptor.wrapper.mock.ComputeMockWrapper;
 import sonata.kernel.VimAdaptor.wrapper.ovsWrapper.OvsWrapper;
 
 import java.io.IOException;
@@ -74,7 +74,7 @@ public class VimRepoTest {
     config.setWrapperType("mock");
     config.setTenantExtNet("ext-subnet");
     config.setTenantExtRouter("ext-router");
-    WrapperRecord record = new WrapperRecord(new MockWrapper(config), config, null);
+    WrapperRecord record = new WrapperRecord(new ComputeMockWrapper(config), config, null);
     boolean out = repoInstance.writeVimEntry(config.getUuid(), record);
 
 
@@ -99,17 +99,17 @@ public class VimRepoTest {
     config.setTenantExtNet("ext-subnet");
     config.setTenantExtRouter("ext-router");
 
-    WrapperRecord record = new WrapperRecord(new MockWrapper(config), config, null);
+    WrapperRecord record = new WrapperRecord(new ComputeMockWrapper(config), config, null);
     boolean out = repoInstance.writeVimEntry(config.getUuid(), record);
     Assert.assertTrue("Unable to write a vim", out);
 
     config.setUuid("2");
-    record = new WrapperRecord(new MockWrapper(config), config, null);
+    record = new WrapperRecord(new ComputeMockWrapper(config), config, null);
     out = repoInstance.writeVimEntry(config.getUuid(), record);
     Assert.assertTrue("Unable to write a vim", out);
 
     config.setUuid("3");
-    record = new WrapperRecord(new MockWrapper(config), config, null);
+    record = new WrapperRecord(new ComputeMockWrapper(config), config, null);
     out = repoInstance.writeVimEntry(config.getUuid(), record);
     Assert.assertTrue("Unable to write a vim", out);
 
@@ -240,7 +240,7 @@ public class VimRepoTest {
     config.setWrapperType("compute");
     config.setTenantExtNet("ext-subnet");
     config.setTenantExtRouter("ext-router");
-    WrapperRecord record = new WrapperRecord(new MockWrapper(config), config, null);
+    WrapperRecord record = new WrapperRecord(new ComputeMockWrapper(config), config, null);
     boolean out = repoInstance.writeVimEntry(config.getUuid(), record);
     Assert.assertTrue("Unable to write the compute vim", out);
 

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/messaging/TestProducer.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/messaging/TestProducer.java
@@ -59,6 +59,15 @@ public class TestProducer extends AbstractMsgBusProducer {
     if (message.getTopic().equals("infrastructure.service.deploy")) {
       output.receive(message);
     }
+    if (message.getTopic().equals("infrastructure.service.prepare")) {
+      output.receive(message);
+    }
+    if (message.getTopic().equals("infrastructure.function.deploy")) {
+      output.receive(message);
+    }
+    if (message.getTopic().equals("infrastructure.network.configure")) {
+      output.receive(message);
+    }
     if (message.getTopic().equals("infrastructure.wan.configure")) {
       output.receive(message);
     }

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/messaging/TestProducer.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/messaging/TestProducer.java
@@ -53,7 +53,7 @@ public class TestProducer extends AbstractMsgBusProducer {
     if (message.getTopic().contains("infrastructure.management.compute")) {
       output.receive(message);
     }
-    if (message.getTopic().contains("infrastructure.management.networking")) {
+    if (message.getTopic().contains("infrastructure.management.network")) {
       output.receive(message);
     }
     if (message.getTopic().equals("infrastructure.service.deploy")) {

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/wrapper/OdlWrapperTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/VimAdaptor/wrapper/OdlWrapperTest.java
@@ -28,13 +28,13 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.Before;
 import org.junit.Ignore;
 
-import sonata.kernel.VimAdaptor.commons.DeployServiceData;
+import sonata.kernel.VimAdaptor.commons.ServiceDeployPayload;
 import sonata.kernel.VimAdaptor.commons.heat.StackComposition;
 import sonata.kernel.VimAdaptor.commons.nsd.ServiceDescriptor;
 import sonata.kernel.VimAdaptor.commons.vnfd.Unit;
 import sonata.kernel.VimAdaptor.commons.vnfd.UnitDeserializer;
 import sonata.kernel.VimAdaptor.commons.vnfd.VnfDescriptor;
-import sonata.kernel.VimAdaptor.wrapper.odlWrapper.OdlWrapper;
+import sonata.kernel.VimAdaptor.wrapper.ovsWrapper.OvsWrapper;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -44,7 +44,7 @@ import java.nio.charset.Charset;
 
 public class OdlWrapperTest {
 
-  private DeployServiceData data;
+  private ServiceDeployPayload data;
   private ObjectMapper mapper;
   private StackComposition composition;
 
@@ -88,7 +88,7 @@ public class OdlWrapperTest {
       bodyBuilder.append(line + "\n\r");
     vnfd2 = mapper.readValue(bodyBuilder.toString(), VnfDescriptor.class);
 
-    this.data = new DeployServiceData();
+    this.data = new ServiceDeployPayload();
     sd.setInstanceUuid(sd.getInstanceUuid() + "IASFCTEST");
     data.setServiceDescriptor(sd);
     data.addVnfDescriptor(vnfd1);
@@ -112,7 +112,7 @@ public class OdlWrapperTest {
 
     config.setVimEndpoint("10.100.32.200");
 
-    OdlWrapper wrapper = new OdlWrapper(config);
+    OvsWrapper wrapper = new OvsWrapper(config);
     try {
       wrapper.configureNetworking(data, composition);
     } catch (Exception e) {

--- a/wim-adaptor/adaptor/src/main/java/sonata/kernel/WimAdaptor/ConfigureWimCallProcessor.java
+++ b/wim-adaptor/adaptor/src/main/java/sonata/kernel/WimAdaptor/ConfigureWimCallProcessor.java
@@ -17,6 +17,7 @@ import sonata.kernel.WimAdaptor.commons.Status;
 import sonata.kernel.WimAdaptor.commons.VnfRecord;
 import sonata.kernel.WimAdaptor.commons.vnfd.UnitDeserializer;
 import sonata.kernel.WimAdaptor.messaging.ServicePlatformMessage;
+import sonata.kernel.WimAdaptor.wrapper.WimWrapper;
 import sonata.kernel.WimAdaptor.wrapper.WrapperBay;
 
 public class ConfigureWimCallProcessor extends AbstractCallProcessor {

--- a/wim-adaptor/adaptor/src/main/java/sonata/kernel/WimAdaptor/wrapper/WimWrapper.java
+++ b/wim-adaptor/adaptor/src/main/java/sonata/kernel/WimAdaptor/wrapper/WimWrapper.java
@@ -1,7 +1,4 @@
-package sonata.kernel.WimAdaptor;
-
-import sonata.kernel.WimAdaptor.wrapper.AbstractWrapper;
-import sonata.kernel.WimAdaptor.wrapper.Wrapper;
+package sonata.kernel.WimAdaptor.wrapper;
 
 public abstract class WimWrapper extends AbstractWrapper implements Wrapper {
 

--- a/wim-adaptor/adaptor/src/main/java/sonata/kernel/WimAdaptor/wrapper/vtn/VtnWrapper.java
+++ b/wim-adaptor/adaptor/src/main/java/sonata/kernel/WimAdaptor/wrapper/vtn/VtnWrapper.java
@@ -29,7 +29,7 @@ package sonata.kernel.WimAdaptor.wrapper.vtn;
 import org.slf4j.LoggerFactory;
 
 import sonata.kernel.WimAdaptor.ConfigureWimCallProcessor;
-import sonata.kernel.WimAdaptor.WimWrapper;
+import sonata.kernel.WimAdaptor.wrapper.WimWrapper;
 import sonata.kernel.WimAdaptor.wrapper.WrapperConfiguration;
 
 public class VtnWrapper extends WimWrapper {


### PR DESCRIPTION
* some renaming of call processor and message payloads to reflect the topic structure of each API call
* renaming of ODL net VIM wrapper to OVS (we don't pass through an ODL controller)
* Edit to the VIM repository data model to cope with the new incremental deployment
* First draft of test for the incremental deployment added (deactivated. Flow implementation not ready)
* Added tests for the new functions of the VIM repository, refined tests to check for referential integrity and cascade delete.