### PR TITLE
Back-compatibility issue

### DIFF
--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/nsd/ConnectionPoint.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/VimAdaptor/commons/nsd/ConnectionPoint.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ConnectionPoint {
 
   public enum Interface {
-    PUBLIC("public"),EXT("external"),INT("internal");
+    PUBLIC("public"),EXT("external"),INT("internal"),INTERFACE("interface");
     private final String name;
 
     Interface(String name) {


### PR DESCRIPTION
Added an allowed value to CP descriptor, "type" field, to ensure back-compatibility with SONATA NSD and VNFD V1