### PR TITLE
Refactor of the translation model to use Heat Resource Groups

### DIFF
--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/RemoveServiceCallProcessor.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/RemoveServiceCallProcessor.java
@@ -102,6 +102,8 @@ public class RemoveServiceCallProcessor extends AbstractCallProcessor {
   public void update(Observable observable, Object arg) {
 
     WrapperStatusUpdate update = (WrapperStatusUpdate) arg;
+    if(!update.getSid().equals(this.getSid()))
+      return;
     Logger.info("Received an update:\n" + update.getBody());
     JSONTokener tokener = new JSONTokener(update.getBody());
     JSONObject jsonObject = (JSONObject) tokener.nextValue();

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatClient.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatClient.java
@@ -43,6 +43,7 @@ import sonata.kernel.vimadaptor.commons.heat.StackComposition;
 import sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.JavaStackCore;
 import sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.JavaStackUtils;
 import sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.models.composition.FloatingIpAttributes;
+import sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.models.composition.Link;
 import sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.models.composition.PortAttributes;
 import sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.models.composition.Resource;
 import sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.models.composition.ResourceData;
@@ -79,7 +80,8 @@ public class OpenStackHeatClient {
    * @param tenantName to log into the OpenStack service
    * @throws IOException if the client cannoct connect to the VIM
    */
-  public OpenStackHeatClient(String url, String userName, String password, String tenantName) throws IOException  {
+  public OpenStackHeatClient(String url, String userName, String password, String tenantName)
+      throws IOException {
     this.url = url;
     this.userName = userName;
     this.password = password;
@@ -97,7 +99,7 @@ public class OpenStackHeatClient {
     javaStack.setAuthenticated(false);
     // Authenticate
     javaStack.authenticateClientV3();
-    
+
   }
 
   /**
@@ -276,16 +278,43 @@ public class OpenStackHeatClient {
         HeatServer heatServer = new HeatServer();
         HeatPort heatPort = new HeatPort();
 
-        // Logger.debug(resource.getResource_type());
+        Logger.debug(resource.getResource_type());
 
         // Show ResourceData
         // Logger.debug("StackID: " + uuid);
 
         String showResourceData = JavaStackUtils.convertHttpResponseToString(
             javaStack.showResourceData(stackName, uuid, resource.getResource_name()));
-
+        Logger.debug(showResourceData);
         switch (resource.getResource_type()) {
+          case "OS::Heat::ResourceGroup":
+            String groupStackUuid = resource.getPhysical_resource_id();
+            String groupStackName = this.getNestedStackName(resource);
+            Logger.debug("Get resource info for nested stack name: " + groupStackName + " -  ID: "
+                + groupStackUuid);
+            String groupListResources = JavaStackUtils.convertHttpResponseToString(
+                javaStack.listStackResources(groupStackName, groupStackUuid, null));
+            
+            ArrayList<Resource> groupResources =
+                mapper.readValue(groupListResources, Resources.class).getResources();
+            Logger.debug("Getting resources for resource group.");
+            String serverInGroupResource = null;
+            for (Resource groupResource : groupResources) {
+              HeatServer server= new HeatServer();
+              serverInGroupResource =
+                  JavaStackUtils.convertHttpResponseToString(javaStack.showResourceData(
+                      groupStackName, groupStackUuid, groupResource.getResource_name()));
 
+              Logger.debug("group resource info: " + serverInGroupResource);
+              ResourceData<ServerAttributes> serverResourceData = mapper.readValue(serverInGroupResource,
+                  new TypeReference<ResourceData<ServerAttributes>>() {});
+              // Set Server
+              server.setServerId(serverResourceData.getResource().getPhysical_resource_id());
+              server.setServerName(serverResourceData.getResource().getParent_resource() +"."+ serverResourceData.getResource().getResource_name());
+              Logger.debug("Server Object created: "+ mapper.writeValueAsString(server));
+              servers.add(server);
+            }
+            break;
           case "OS::Nova::Server":
             ResourceData<ServerAttributes> serverResourceData = mapper.readValue(showResourceData,
                 new TypeReference<ResourceData<ServerAttributes>>() {});
@@ -349,7 +378,7 @@ public class OpenStackHeatClient {
       composition.setPorts(ports);
       composition.setNets(networks);
       composition.setRouters(routers);
-
+      Logger.debug("Forged composition: " + mapper.writeValueAsString(composition));
     } catch (Exception e) {
       Logger.error("Runtime error getting composition for stack : " + stackName + " error message: "
           + e.getMessage());
@@ -357,5 +386,24 @@ public class OpenStackHeatClient {
     }
 
     return composition;
+  }
+
+  /**
+   * @param resource
+   * @return
+   */
+  private String getNestedStackName(Resource resource) {
+    ArrayList<Link> links = resource.getLinks();
+    Link nestedLink = null;
+    for (Link l : links) {
+      if (l.getRel().equals("nested")) {
+        nestedLink = l;
+        break;
+      }
+    }
+
+    String href = nestedLink.getHref();
+    String[] elements = href.split("/");
+    return elements[6];
   }
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatClient.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatClient.java
@@ -130,7 +130,7 @@ public class OpenStackHeatClient {
     return uuid;
   }
 
-  public void updateStack(String stackName, String stackUuid, String template) {
+  public void updateStack(String stackName, String stackUuid, String template) throws Exception {
 
     Logger.info("Creating stack: " + stackName);
     // Logger.debug("Template:\n" + template);
@@ -143,6 +143,7 @@ public class OpenStackHeatClient {
     } catch (Exception e) {
       Logger.error(
           "Runtime error creating stack : " + stackName + " error message: " + e.getMessage());
+      throw new Exception("Runtime error creating stack : " + stackName + " error message: " + e.getMessage());
     }
 
     return;

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatWrapper.java
@@ -797,6 +797,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
         port.setName(vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
         port.putProperty("name", vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
         HashMap<String, Object> netMap = new HashMap<String, Object>();
+        Logger.debug("Mapping CP Type to the relevant network");
         if (cp.getType().equals(ConnectionPointType.INT)) {
           netMap.put("get_resource", "SonataService:data:net:" + instanceUuid);
         } else if (cp.getType().equals(ConnectionPointType.EXT)) {
@@ -804,6 +805,9 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
         } else if (cp.getType().equals(ConnectionPointType.MANAGEMENT)) {
           netMap.put("get_resource", "SonataService:mgmt:net:" + instanceUuid);
           publicPortNames.add(vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
+        } else{
+          Logger.error("Cannot map the parsed CP type " + cp.getType() + " to a known one");
+          throw new Exception("Unable to translate CP "+ vnfd.getName()+":"+cp.getId());
         }
         port.putProperty("network", netMap);
         model.addResource(port);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatWrapper.java
@@ -1060,8 +1060,8 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
           continue;
         }
         String vduName = identifiers[1];
-        //String instanceId = identifiers[3];
-        String vnfcIndex = identifiers[2];
+        //String instanceId = identifiers[2];
+        String vnfcIndex = identifiers[3];
         if (vdu.getId().equals(vduName)) {
           VnfcInstance vnfc = new VnfcInstance();
           vnfc.setId(vnfcIndex);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatWrapper.java
@@ -124,15 +124,15 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
 
     HeatResource mgmtNetwork = new HeatResource();
     mgmtNetwork.setType("OS::Neutron::Net");
-    mgmtNetwork.setName("SonataService:mgmt:net:" + instanceId);
-    mgmtNetwork.putProperty("name", "SonatService" + ":mgmt:net:" + instanceId);
+    mgmtNetwork.setName("SonataService.mgmt.net." + instanceId);
+    mgmtNetwork.putProperty("name", "SonatService" + ".mgmt.net." + instanceId);
     model.addResource(mgmtNetwork);
 
     HeatResource mgmtSubnet = new HeatResource();
 
     mgmtSubnet.setType("OS::Neutron::Subnet");
-    mgmtSubnet.setName("SonataService:mgmt:subnet:" + instanceId);
-    mgmtSubnet.putProperty("name", "SonataService:mgmt:subnet:" + instanceId);
+    mgmtSubnet.setName("SonataService.mgmt.subnet." + instanceId);
+    mgmtSubnet.putProperty("name", "SonataService.mgmt.subnet." + instanceId);
     String cidr = subnets.get(subnetIndex);
     mgmtSubnet.putProperty("cidr", cidr);
     mgmtSubnet.putProperty("gateway_ip", myPool.getGateway(cidr));
@@ -140,38 +140,38 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     mgmtSubnet.putProperty("dns_nameservers", dnsArray);
     subnetIndex++;
     HashMap<String, Object> mgmtNetMap = new HashMap<String, Object>();
-    mgmtNetMap.put("get_resource", "SonataService:mgmt:net:" + instanceId);
+    mgmtNetMap.put("get_resource", "SonataService.mgmt.net." + instanceId);
     mgmtSubnet.putProperty("network", mgmtNetMap);
     model.addResource(mgmtSubnet);
 
     // Internal mgmt router interface
     HeatResource mgmtRouterInterface = new HeatResource();
     mgmtRouterInterface.setType("OS::Neutron::RouterInterface");
-    mgmtRouterInterface.setName("SonataService:mgmt:internal:" + instanceId);
+    mgmtRouterInterface.setName("SonataService.mgmt.internal." + instanceId);
     HashMap<String, Object> mgmtSubnetMapInt = new HashMap<String, Object>();
-    mgmtSubnetMapInt.put("get_resource", "SonataService:mgmt:subnet:" + instanceId);
+    mgmtSubnetMapInt.put("get_resource", "SonataService.mgmt.subnet." + instanceId);
     mgmtRouterInterface.putProperty("subnet", mgmtSubnetMapInt);
     mgmtRouterInterface.putProperty("router", tenantExtRouter);
     model.addResource(mgmtRouterInterface);
 
     HeatResource dataNetwork = new HeatResource();
     dataNetwork.setType("OS::Neutron::Net");
-    dataNetwork.setName("SonataService:data:net:" + instanceId);
-    dataNetwork.putProperty("name", "SonatService:data:net:" + instanceId);
+    dataNetwork.setName("SonataService.data.net." + instanceId);
+    dataNetwork.putProperty("name", "SonatService.data.net." + instanceId);
     model.addResource(dataNetwork);
 
     // Create the data subnet
     HeatResource dataSubnet = new HeatResource();
 
     dataSubnet.setType("OS::Neutron::Subnet");
-    dataSubnet.setName("SonataService:data:subnet:" + instanceId);
-    dataSubnet.putProperty("name", "SonataService:data:subnet:" + instanceId);
+    dataSubnet.setName("SonataService.data.subnet." + instanceId);
+    dataSubnet.putProperty("name", "SonataService.data.subnet." + instanceId);
     cidr = subnets.get(subnetIndex);
     dataSubnet.putProperty("cidr", cidr);
     dataSubnet.putProperty("gateway_ip", myPool.getGateway(cidr));
     subnetIndex++;
     HashMap<String, Object> dataNetMap = new HashMap<String, Object>();
-    dataNetMap.put("get_resource", "SonataService:data:net:" + instanceId);
+    dataNetMap.put("get_resource", "SonataService.data.net." + instanceId);
     dataSubnet.putProperty("network", dataNetMap);
     model.addResource(dataSubnet);
 
@@ -257,6 +257,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
 
   @Override
   public ResourceUtilisation getResourceUtilisation() {
+    long start = System.currentTimeMillis(); 
     // TODO This values should be per User, now they are per VIM. This should be re-desinged once
     // user management is in place.
     JSONTokener tokener = new JSONTokener(getConfig().getConfiguration());
@@ -282,6 +283,8 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
       output.setTotMemory(0);
       output.setUsedMemory(0);      
     }
+    long stop = System.currentTimeMillis();
+    Logger.info("[OpenStackWrapper]getResourceUtilisation-time: " + (stop-start) + " ms");
     return output;
   }
 
@@ -294,6 +297,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
    */
   @Override
   public boolean prepareService(String instanceId) throws Exception {
+    long start = System.currentTimeMillis();
     // TODO This values should be per User, now they are per VIM. This should be re-desinged once
     // user management is in place.
     JSONTokener tokener = new JSONTokener(getConfig().getConfiguration());
@@ -363,14 +367,15 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
       Logger.error(e.getMessage());
       return false;
     }
-
+    long stop = System.currentTimeMillis();
+    Logger.info("[OpenStackWrapper]PrepareService-time: " + (stop-start) + " ms");
     return true;
 
   }
 
   @Override
   public boolean removeService(String instanceUuid, String callSid) {
-
+    long start = System.currentTimeMillis();
     // TODO This values should be per User, now they are per VIM. This should be re-desinged once
     // user management is in place.
     JSONTokener tokener = new JSONTokener(getConfig().getConfiguration());
@@ -420,7 +425,8 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
       this.notifyObservers(errorUpdate);
       return false;
     }
-
+    long stop = System.currentTimeMillis();
+    Logger.info("[OpenStackWrapper]RemoveService-time: " + (stop-start) + " ms");
     return true;
   }
 
@@ -474,8 +480,8 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     // Create the management Net and subnet for all the VNFCs and VNFs
     HeatResource mgmtNetwork = new HeatResource();
     mgmtNetwork.setType("OS::Neutron::Net");
-    mgmtNetwork.setName(nsd.getName() + ":mgmt:net:" + nsd.getInstanceUuid());
-    mgmtNetwork.putProperty("name", nsd.getName() + ":mgmt:net:" + nsd.getInstanceUuid());
+    mgmtNetwork.setName(nsd.getName() + ".mgmt.net." + nsd.getInstanceUuid());
+    mgmtNetwork.putProperty("name", nsd.getName() + ".mgmt.net." + nsd.getInstanceUuid());
 
 
 
@@ -485,8 +491,8 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     HeatResource mgmtSubnet = new HeatResource();
 
     mgmtSubnet.setType("OS::Neutron::Subnet");
-    mgmtSubnet.setName(nsd.getName() + ":mgmt:subnet:" + nsd.getInstanceUuid());
-    mgmtSubnet.putProperty("name", nsd.getName() + ":mgmt:subnet:" + nsd.getInstanceUuid());
+    mgmtSubnet.setName(nsd.getName() + ".mgmt.subnet." + nsd.getInstanceUuid());
+    mgmtSubnet.putProperty("name", nsd.getName() + ".mgmt.subnet." + nsd.getInstanceUuid());
     String cidr = subnets.get(subnetIndex);
     mgmtSubnet.putProperty("cidr", cidr);
     mgmtSubnet.putProperty("gateway_ip", myPool.getGateway(cidr));
@@ -496,7 +502,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
 
     subnetIndex++;
     HashMap<String, Object> mgmtNetMap = new HashMap<String, Object>();
-    mgmtNetMap.put("get_resource", nsd.getName() + ":mgmt:net:" + nsd.getInstanceUuid());
+    mgmtNetMap.put("get_resource", nsd.getName() + ".mgmt.net." + nsd.getInstanceUuid());
     mgmtSubnet.putProperty("network", mgmtNetMap);
     model.addResource(mgmtSubnet);
 
@@ -504,9 +510,9 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     // Internal mgmt router interface
     HeatResource mgmtRouterInterface = new HeatResource();
     mgmtRouterInterface.setType("OS::Neutron::RouterInterface");
-    mgmtRouterInterface.setName(nsd.getName() + ":mgmt:internal:" + nsd.getInstanceUuid());
+    mgmtRouterInterface.setName(nsd.getName() + ".mgmt.internal." + nsd.getInstanceUuid());
     HashMap<String, Object> mgmtSubnetMapInt = new HashMap<String, Object>();
-    mgmtSubnetMapInt.put("get_resource", nsd.getName() + ":mgmt:subnet:" + nsd.getInstanceUuid());
+    mgmtSubnetMapInt.put("get_resource", nsd.getName() + ".mgmt.subnet." + nsd.getInstanceUuid());
     mgmtRouterInterface.putProperty("subnet", mgmtSubnetMapInt);
     mgmtRouterInterface.putProperty("router", tenantExtRouter);
     model.addResource(mgmtRouterInterface);
@@ -528,10 +534,10 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
       }
       if (isInterVnf && !isMgmt) {
         HeatResource router = new HeatResource();
-        router.setName(nsd.getName() + ":" + link.getId() + ":" + nsd.getInstanceUuid());
+        router.setName(nsd.getName() + "." + link.getId() + "." + nsd.getInstanceUuid());
         router.setType("OS::Neutron::Router");
         router.putProperty("name",
-            nsd.getName() + ":" + link.getId() + ":" + nsd.getInstanceUuid());
+            nsd.getName() + "." + link.getId() + "." + nsd.getInstanceUuid());
         model.addResource(router);
       }
     }
@@ -545,15 +551,15 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
         if (!link.getId().equals("mgmt")) {
           HeatResource network = new HeatResource();
           network.setType("OS::Neutron::Net");
-          network.setName(vnfd.getName() + ":" + link.getId() + ":net:" + nsd.getInstanceUuid());
+          network.setName(vnfd.getName() + "." + link.getId() + ".net." + nsd.getInstanceUuid());
           network.putProperty("name",
-              vnfd.getName() + ":" + link.getId() + ":net:" + nsd.getInstanceUuid());
+              vnfd.getName() + "." + link.getId() + ".net." + nsd.getInstanceUuid());
           model.addResource(network);
           HeatResource subnet = new HeatResource();
           subnet.setType("OS::Neutron::Subnet");
-          subnet.setName(vnfd.getName() + ":" + link.getId() + ":subnet:" + nsd.getInstanceUuid());
+          subnet.setName(vnfd.getName() + "." + link.getId() + ".subnet." + nsd.getInstanceUuid());
           subnet.putProperty("name",
-              vnfd.getName() + ":" + link.getId() + ":subnet:" + nsd.getInstanceUuid());
+              vnfd.getName() + "." + link.getId() + ".subnet." + nsd.getInstanceUuid());
           cidr = subnets.get(subnetIndex);
           subnet.putProperty("cidr", cidr);
           // getConfig() parameter
@@ -567,7 +573,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
           subnetIndex++;
           HashMap<String, Object> netMap = new HashMap<String, Object>();
           netMap.put("get_resource",
-              vnfd.getName() + ":" + link.getId() + ":net:" + nsd.getInstanceUuid());
+              vnfd.getName() + "." + link.getId() + ":net:" + nsd.getInstanceUuid());
           subnet.putProperty("network", netMap);
           model.addResource(subnet);
         }
@@ -577,9 +583,9 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
       for (VirtualDeploymentUnit vdu : vnfd.getVirtualDeploymentUnits()) {
         HeatResource server = new HeatResource();
         server.setType("OS::Nova::Server");
-        server.setName(vnfd.getName() + ":" + vdu.getId() + ":" + nsd.getInstanceUuid());
+        server.setName(vnfd.getName() + "." + vdu.getId() + "." + nsd.getInstanceUuid());
         server.putProperty("name",
-            vnfd.getName() + ":" + vdu.getId() + ":" + nsd.getInstanceUuid());
+            vnfd.getName() + "." + vdu.getId() + "." + nsd.getInstanceUuid());
         server.putProperty("image", vdu.getVmImage());
         int vcpu = vdu.getResourceRequirements().getCpu().getVcpus();
         double memoryInBytes = vdu.getResourceRequirements().getMemory().getSize()
@@ -611,31 +617,31 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
             // connect this VNFC CP to the mgmt network
             HeatResource port = new HeatResource();
             port.setType("OS::Neutron::Port");
-            port.setName(vnfd.getName() + ":" + cp.getId() + ":" + nsd.getInstanceUuid());
+            port.setName(vnfd.getName() + "." + cp.getId() + "." + nsd.getInstanceUuid());
             port.putProperty("name",
-                vnfd.getName() + ":" + cp.getId() + ":" + nsd.getInstanceUuid());
+                vnfd.getName() + "." + cp.getId() + "." + nsd.getInstanceUuid());
             HashMap<String, Object> netMap = new HashMap<String, Object>();
-            netMap.put("get_resource", nsd.getName() + ":mgmt:net:" + nsd.getInstanceUuid());
+            netMap.put("get_resource", nsd.getName() + ".mgmt.net." + nsd.getInstanceUuid());
             port.putProperty("network", netMap);
             model.addResource(port);
-            mgmtPortNames.add(vnfd.getName() + ":" + cp.getId() + ":" + nsd.getInstanceUuid());
+            mgmtPortNames.add(vnfd.getName() + "." + cp.getId() + "." + nsd.getInstanceUuid());
 
             // add the port to the server
             HashMap<String, Object> n1 = new HashMap<String, Object>();
             HashMap<String, Object> portMap = new HashMap<String, Object>();
             portMap.put("get_resource",
-                vnfd.getName() + ":" + cp.getId() + ":" + nsd.getInstanceUuid());
+                vnfd.getName() + "." + cp.getId() + "." + nsd.getInstanceUuid());
             n1.put("port", portMap);
             net.add(n1);
           } else if (linkIdReference != null) {
             HeatResource port = new HeatResource();
             port.setType("OS::Neutron::Port");
-            port.setName(vnfd.getName() + ":" + cp.getId() + ":" + nsd.getInstanceUuid());
+            port.setName(vnfd.getName() + "." + cp.getId() + "." + nsd.getInstanceUuid());
             port.putProperty("name",
-                vnfd.getName() + ":" + cp.getId() + ":" + nsd.getInstanceUuid());
+                vnfd.getName() + "." + cp.getId() + "." + nsd.getInstanceUuid());
             HashMap<String, Object> netMap = new HashMap<String, Object>();
             netMap.put("get_resource",
-                vnfd.getName() + ":" + linkIdReference + ":net:" + nsd.getInstanceUuid());
+                vnfd.getName() + "." + linkIdReference + ".net." + nsd.getInstanceUuid());
             port.putProperty("network", netMap);
 
             model.addResource(port);
@@ -643,7 +649,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
             HashMap<String, Object> n1 = new HashMap<String, Object>();
             HashMap<String, Object> portMap = new HashMap<String, Object>();
             portMap.put("get_resource",
-                vnfd.getName() + ":" + cp.getId() + ":" + nsd.getInstanceUuid());
+                vnfd.getName() + "." + cp.getId() + "." + nsd.getInstanceUuid());
             n1.put("port", portMap);
             net.add(n1);
           }
@@ -689,7 +695,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
                 }
               }
               if (!isInOut) {
-                nsVirtualLink = nsd.getName() + ":" + link.getId() + ":" + nsd.getInstanceUuid();
+                nsVirtualLink = nsd.getName() + "." + link.getId() + "." + nsd.getInstanceUuid();
               }
               break;
             }
@@ -697,19 +703,19 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
           if (!isVirtualLinkFound) {
             throw new Exception("Error binding VNFD.connection_point:"
                 + " Cannot find NSD.virtual_link attached to VNFD.connection_point."
-                + " VNFD.connection_point = " + vnfd.getName() + ":" + cp.getId());
+                + " VNFD.connection_point = " + vnfd.getName() + "." + cp.getId());
           }
           if (!isInOut) {
             HeatResource routerInterface = new HeatResource();
             routerInterface.setType("OS::Neutron::RouterInterface");
             routerInterface
-                .setName(vnfd.getName() + ":" + cp.getId() + ":" + nsd.getInstanceUuid());
+                .setName(vnfd.getName() + "." + cp.getId() + "." + nsd.getInstanceUuid());
 
             for (VnfVirtualLink link : links) {
               if (link.getConnectionPointsReference().contains(cp.getId())) {
                 HashMap<String, Object> subnetMap = new HashMap<String, Object>();
                 subnetMap.put("get_resource",
-                    vnfd.getName() + ":" + link.getId() + ":subnet:" + nsd.getInstanceUuid());
+                    vnfd.getName() + "." + link.getId() + ".subnet." + nsd.getInstanceUuid());
                 routerInterface.putProperty("subnet", subnetMap);
                 break;
               }
@@ -761,11 +767,15 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     ArrayList<String> publicPortNames = new ArrayList<String>();
 
     for (VirtualDeploymentUnit vdu : vnfd.getVirtualDeploymentUnits()) {
-      Logger.debug("Each VDU goes into a number of Heat Server...");
+      Logger.debug("Each VDU goes into a resource group with a number of Heat Server...");
+      HeatResource resourceGroup = new HeatResource();
+      resourceGroup.setType("OS::Heat::ResourceGroup");
+      resourceGroup.setName(vnfd.getName() + "." + vdu.getId() + "." + instanceUuid);
+      resourceGroup.putProperty("count", new Integer(1));
       HeatResource server = new HeatResource();
       server.setType("OS::Nova::Server");
-      server.setName(vnfd.getName() + ":" + vdu.getId() + ":" + instanceUuid);
-      server.putProperty("name", vnfd.getName() + ":" + vdu.getId() + ":" + instanceUuid);
+      server.setName(null);
+      server.putProperty("name", vnfd.getName() + "." + vdu.getId() + "." + instanceUuid + ".%index%");
       server.putProperty("image",
           vnfd.getVendor() + "_" + vnfd.getName() + "_" + vnfd.getVersion() + "_" + vdu.getId());
       int vcpu = vdu.getResourceRequirements().getCpu().getVcpus();
@@ -794,17 +804,20 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
         // create the port resource
         HeatResource port = new HeatResource();
         port.setType("OS::Neutron::Port");
-        port.setName(vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
-        port.putProperty("name", vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
+        port.setName(vnfd.getName() + "." + cp.getId() + "." + instanceUuid);
+        port.putProperty("name", vnfd.getName() + "." + cp.getId() + "." + instanceUuid);
         HashMap<String, Object> netMap = new HashMap<String, Object>();
         Logger.debug("Mapping CP Type to the relevant network");
         if (cp.getType().equals(ConnectionPointType.INT)) {
-          netMap.put("get_resource", "SonataService:data:net:" + instanceUuid);
+          //Only able access other VNFC from this port
+          netMap.put("get_resource", "SonataService.data.net." + instanceUuid);
         } else if (cp.getType().equals(ConnectionPointType.EXT)) {
-          netMap.put("get_resource", "SonataService:mgmt:net:" + instanceUuid);
+          //Able to access internet through this port, but not vice-versa
+          netMap.put("get_resource", "SonataService.mgmt.net." + instanceUuid);
         } else if (cp.getType().equals(ConnectionPointType.MANAGEMENT)) {
-          netMap.put("get_resource", "SonataService:mgmt:net:" + instanceUuid);
-          publicPortNames.add(vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
+          //Get a public IP
+          netMap.put("get_resource", "SonataService.mgmt.net." + instanceUuid);
+          publicPortNames.add(vnfd.getName() + "." + cp.getId() + "." + instanceUuid);
         } else{
           Logger.error("Cannot map the parsed CP type " + cp.getType() + " to a known one");
           throw new Exception("Unable to translate CP "+ vnfd.getName()+":"+cp.getId());
@@ -815,12 +828,13 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
         // add the port to the server
         HashMap<String, Object> n1 = new HashMap<String, Object>();
         HashMap<String, Object> portMap = new HashMap<String, Object>();
-        portMap.put("get_resource", vnfd.getName() + ":" + cp.getId() + ":" + instanceUuid);
+        portMap.put("get_resource", vnfd.getName() + "." + cp.getId() + "." + instanceUuid);
         n1.put("port", portMap);
         net.add(n1);
       }
       server.putProperty("networks", net);
-      model.addResource(server);
+      resourceGroup.putProperty("resource_def", server);
+      model.addResource(resourceGroup);
     }
 
     for (String portName : publicPortNames) {
@@ -851,6 +865,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
    */
   @Override
   public synchronized void deployFunction(FunctionDeployPayload data, String sid) {
+    Long start = System.currentTimeMillis();
     // TODO This values should be per User, now they are per VIM. This should be re-desinged once
     // user management is in place.
     JSONTokener tokener = new JSONTokener(getConfig().getConfiguration());
@@ -1039,22 +1054,23 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
 
       // HeatServer matchingServer = null;
       for (HeatServer server : composition.getServers()) {
-        String[] identifiers = server.getServerName().split(":");
+        String[] identifiers = server.getServerName().split("\\.");
         String vnfName = identifiers[0];
-        String vduName = identifiers[1];
         if(!vnfName.equals(vnfd.getName())){
           continue;
         }
-        String instanceId = identifiers[2];
+        String vduName = identifiers[1];
+        //String instanceId = identifiers[3];
+        String vnfcIndex = identifiers[2];
         if (vdu.getId().equals(vduName)) {
           VnfcInstance vnfc = new VnfcInstance();
-          vnfc.setId(instanceId);
+          vnfc.setId(vnfcIndex);
           vnfc.setVimId(data.getVimUuid());
           vnfc.setVcId(server.getServerId());
           ArrayList<ConnectionPointRecord> cpRecords = new ArrayList<ConnectionPointRecord>();
           for (ConnectionPoint cp : vdu.getConnectionPoints()) {
             Logger.debug("Mapping CP " + cp.getId());
-            Logger.debug("Looking for port " + vnfd.getName() + ":" + cp.getId() + ":"
+            Logger.debug("Looking for port " + vnfd.getName() + "." + cp.getId() + "."
                 + data.getServiceInstanceId());
             ConnectionPointRecord cpr = new ConnectionPointRecord();
             cpr.setId(cp.getId());
@@ -1066,7 +1082,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
             for (HeatPort port : composition.getPorts()) {
               Logger.debug("port " + port.getPortName());
               if (port.getPortName()
-                  .equals(vnfd.getName() + ":" + cp.getId() + ":" + data.getServiceInstanceId())) {
+                  .equals(vnfd.getName() + "." + cp.getId() + "." + data.getServiceInstanceId())) {
                 found = true;
                 Logger.debug("Found! Filling VDUR parameters");
                 InterfaceRecord ip = new InterfaceRecord();
@@ -1122,7 +1138,9 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     WrapperStatusUpdate update = new WrapperStatusUpdate(sid, "SUCCESS", body);
     this.markAsChanged();
     this.notifyObservers(update);
-
+    long stop = System.currentTimeMillis();
+    
+    Logger.info("[OpenStackWrapper]FunctionDeploy-time: " + (stop-start) + " ms");
   }
 
   /*
@@ -1132,6 +1150,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
    */
   @Override
   public void uploadImage(VnfImage image) throws IOException {
+    long start = System.currentTimeMillis();
     // TODO This values should be per User, now they are per VIM. This should be re-desinged once
     // user management is in place.
     JSONTokener tokener = new JSONTokener(getConfig().getConfiguration());
@@ -1168,7 +1187,9 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
       throw new IOException("Error deleting the temporary image file " + fileName
           + " from local environment. Relevant VNF: " + image.getUuid());
     }
-
+    long stop = System.currentTimeMillis();
+    
+    Logger.info("[OpenStackWrapper]UploadImage-time: " + (stop-start) + " ms");
   }
 
   /*
@@ -1178,6 +1199,7 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
    */
   @Override
   public boolean isImageStored(VnfImage image, String callSid) {
+    long start = System.currentTimeMillis();
     // TODO This values should be per User, now they are per VIM. This should be re-desinged once
     // user management is in place.
     Logger.debug("Checking image: " + image.getUuid());
@@ -1203,6 +1225,8 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
     for (Image glanceImage : glanceImages) {
       Logger.debug("Checking " + glanceImage.getName());
       if (glanceImage.getName().equals(image.getUuid())) {
+        long stop = System.currentTimeMillis();
+        Logger.info("[OpenStackWrapper]isImageStored-time: " + (stop-start) + " ms");
         return true;
       }
     }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/OpenStackHeatWrapper.java
@@ -928,8 +928,16 @@ public class OpenStackHeatWrapper extends ComputeWrapper {
       return;
     }
     Logger.debug(stackString);
+    try{
     client.updateStack(stackName, stackUuid, stackString);
-
+    } catch (Exception e) {
+      Logger.error(e.getMessage());
+      WrapperStatusUpdate update =
+          new WrapperStatusUpdate(sid, "ERROR", "Exception during VNF Deployment");
+      this.markAsChanged();
+      this.notifyObservers(update);
+      return;
+    }
     int counter = 0;
     int wait = 1000;
     int maxCounter = 10;

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/JavaStackCore.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/JavaStackCore.java
@@ -353,7 +353,7 @@ public class JavaStackCore {
                 break;
 
               default:
-                System.out.println("Invalid Type");
+                Logger.warn("[JavaStack]Unhandled endpoint type: "+type+". skipping");
             }
           }
         }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/JavaStackUtils.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/JavaStackUtils.java
@@ -38,6 +38,8 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import javax.ws.rs.NotFoundException;
+
 public class JavaStackUtils {
 
   private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(JavaStackCore.class);
@@ -77,6 +79,8 @@ public class JavaStackUtils {
       } else {
         return null;
       }
+    } else if(status == 404){
+      throw new NotFoundException("Resource doesn't exists");
     } else if (status == 403) {
       throw new IOException(
           "Access forbidden, make sure you are using the correct credentials: " + reasonPhrase);

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/models/composition/Link.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/models/composition/Link.java
@@ -1,0 +1,39 @@
+/**
+ * @author Dario Valocchi (Ph.D.)
+ * @mail d.valocchi@ucl.ac.uk
+ * 
+ *       Copyright 2016 [Dario Valocchi]
+ * 
+ *       Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *       except in compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *       Unless required by applicable law or agreed to in writing, software distributed under the
+ *       License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *       either express or implied. See the License for the specific language governing permissions
+ *       and limitations under the License.
+ * 
+ */
+package sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.models.composition;
+
+public class Link {
+
+  String href;
+  String rel;
+  
+  public String getHref() {
+    return href;
+  }
+  public String getRel() {
+    return rel;
+  }
+  public void setHref(String href) {
+    this.href = href;
+  }
+  public void setRel(String rel) {
+    this.rel = rel;
+  }
+  
+  
+}

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/models/composition/Resource.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/openstack/javastackclient/models/composition/Resource.java
@@ -28,13 +28,20 @@ package sonata.kernel.vimadaptor.wrapper.openstack.javastackclient.models.compos
 
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Resource<T> {
-
+  
+  @JsonProperty("parent_resource")
+  String parent_resource;
+  
   String resource_name;
   String resource_type;
   String physical_resource_id;
+  ArrayList<Link> links;
 
   T attributes;
 
@@ -70,5 +77,20 @@ public class Resource<T> {
     this.resource_type = resource_type;
   }
 
+  public ArrayList<Link> getLinks() {
+    return links;
+  }
+
+  public void setLinks(ArrayList<Link> links) {
+    this.links = links;
+  }
+
+  public String getParent_resource() {
+    return parent_resource;
+  }
+
+  public void setParent_resource(String parent_resource) {
+    this.parent_resource = parent_resource;
+  }
 
 }

--- a/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/ovsWrapper/OvsWrapper.java
+++ b/vim-adaptor/adaptor/src/main/java/sonata/kernel/vimadaptor/wrapper/ovsWrapper/OvsWrapper.java
@@ -176,12 +176,12 @@ public class OvsWrapper extends NetworkWrapper {
               "Illegal Format: Unable to find the VNFC Cp name connected to this in/out VNF VL");
         }
 
-        // Logger.debug("Searching for CpRecord of Cp: " + vnfcCpName);
+        Logger.debug("Searching for CpRecord of Cp: " + vnfcCpName);
         ConnectionPointRecord matchingCpRec = null;
         for (VduRecord vdu : vnfr.getVirtualDeploymentUnits()) {
           for (VnfcInstance vnfc : vdu.getVnfcInstance()) {
             for (ConnectionPointRecord cpRec : vnfc.getConnectionPoints()) {
-              // Logger.debug("Checking " + cpRec.getId());
+              Logger.debug("Checking " + cpRec.getId());
               if (vnfcCpName.equals(cpRec.getId())) {
                 matchingCpRec = cpRec;
                 break;
@@ -191,7 +191,7 @@ public class OvsWrapper extends NetworkWrapper {
 
         }
 
-        String qualifiedName = vnfName + ":" + vnfcCpName + ":" + nsd.getInstanceUuid();
+        String qualifiedName = vnfName + "." + vnfcCpName + "." + nsd.getInstanceUuid();
         // HeatPort connectedPort = null;
         // for (HeatPort port : composition.getPorts()) {
         // if (port.getPortName().equals(qualifiedName)) {
@@ -201,7 +201,7 @@ public class OvsWrapper extends NetworkWrapper {
         // }
         if (matchingCpRec == null) {
           throw new Exception(
-              "Illegal Format: cannot find the VNFR:VDU:VNFC:CPR matching: " + vnfcCpName);
+              "Illegal Format: cannot find the VNFR.VDU.VNFC.CPR matching: " + vnfcCpName);
         } else {
           // Eureka!
           OrderedMacAddress mac = new OrderedMacAddress();

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/vimadaptor/DeployServiceTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/vimadaptor/DeployServiceTest.java
@@ -1015,7 +1015,7 @@ public class DeployServiceTest implements MessageReceiver {
    *
    * @throws Exception
    */
-  @Ignore
+  @Test
   public void testDeployServiceIncremental() throws Exception {
     BlockingQueue<ServicePlatformMessage> muxQueue =
         new LinkedBlockingQueue<ServicePlatformMessage>();

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/vimadaptor/DeployServiceTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/vimadaptor/DeployServiceTest.java
@@ -1015,7 +1015,7 @@ public class DeployServiceTest implements MessageReceiver {
    *
    * @throws Exception
    */
-  @Test
+  @Ignore
   public void testDeployServiceIncremental() throws Exception {
     BlockingQueue<ServicePlatformMessage> muxQueue =
         new LinkedBlockingQueue<ServicePlatformMessage>();

--- a/vim-adaptor/adaptor/src/test/java/sonata/kernel/vimadaptor/DeployServiceTest.java
+++ b/vim-adaptor/adaptor/src/test/java/sonata/kernel/vimadaptor/DeployServiceTest.java
@@ -1015,7 +1015,7 @@ public class DeployServiceTest implements MessageReceiver {
    *
    * @throws Exception
    */
-  @Ignore
+  @Test
   public void testDeployServiceIncremental() throws Exception {
     BlockingQueue<ServicePlatformMessage> muxQueue =
         new LinkedBlockingQueue<ServicePlatformMessage>();
@@ -1041,6 +1041,17 @@ public class DeployServiceTest implements MessageReceiver {
     }
 
 
+    // Test PoP
+    // PoP Athens.200 Newton
+//    String addVimBody = "{\"vim_type\":\"Heat\", " +"\"name\":\"Athens1\"," + "\"configuration\":{"
+//        + "\"tenant_ext_router\":\"9303604f-bbf1-457a-824a-0229d103398e\", "
+//        + "\"tenant_ext_net\":\"7666cbd8-6795-4fc3-a08c-af410b63ee43\"," + "\"tenant\":\"admin\""
+//        + "}," + "\"city\":\"Athens\",\"country\":\"Greece\","
+//        + "\"vim_address\":\"10.101.20.2\",\"username\":\"dario\","
+//        + "\"pass\":\"d@rio\"}";
+//    System.out.println("[TwoPoPTest] Adding test PoP .20.2");
+    
+    
     // Add first PoP
     // PoP Athens.200 Mitaka
     String addVimBody = "{\"vim_type\":\"Heat\", " +"\"name\":\"Athens1\"," + "\"configuration\":{"
@@ -1049,8 +1060,8 @@ public class DeployServiceTest implements MessageReceiver {
         + "}," + "\"city\":\"Athens\",\"country\":\"Greece\","
         + "\"vim_address\":\"10.100.32.200\",\"username\":\"sonata.dario\","
         + "\"pass\":\"s0n@t@.d@ri0\"}";
-
     System.out.println("[TwoPoPTest] Adding PoP .200");
+    
     // Add first PoP
     // PoP Athens.201 Newton
     // String addVimBody = "{\"vim_type\":\"Heat\", " + "\"configuration\":{"


### PR DESCRIPTION
* Translation model updated to use Resource Groups
* Since resource groups doesn't allow names to use ":" char, the naming policy of the translation model has been updated to use "." as separator char.
